### PR TITLE
Starting to get rid of Controller class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Homestead.yaml
 /resources/assets/ckeditor45
 /resources/assets/ckeditor/samples
 /database/*.db
+.phpunit.result.cache
+TESTS-*.xml

--- a/app/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Controllers/Auth/ForgotPasswordController.php
@@ -2,9 +2,8 @@
 
 namespace App\Controllers\Auth;
 
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
-use \App\Libs\ViewResolver;
 
 class ForgotPasswordController extends Controller
 {
@@ -26,21 +25,16 @@ class ForgotPasswordController extends Controller
      *
      * @return void
      */
-    public function __construct(ViewResolver $viewResolver)
+    public function __construct()
     {
-
-        $this->view = $viewResolver;
         $this->middleware('guest');
-
     }
 
     public function showLinkRequestForm()
     {
-        $this->view->title("Forgot password");
-        return $this->view->render('auth/passwords/email',[
-                                                    'app_name' => \Config::get('app.name'),
-                                                    'admin_logo' => url(\Config::get('horizontcms.admin_logo')),
-                                                ]);
+        return view('auth.passwords.email', [
+            'app_name' => \Config::get('app.name'),
+            'admin_logo' => url(\Config::get('horizontcms.admin_logo')),
+        ]);
     }
-
 }

--- a/app/Controllers/Auth/LoginController.php
+++ b/app/Controllers/Auth/LoginController.php
@@ -26,10 +26,8 @@ class LoginController extends Controller
      *
      * @return void
      */
-    public function __construct(Request $request)
+    public function __construct()
     {
-        parent::__construct($request);
-
         $this->middleware('guest', ['except' => 'logout']);
     }
 

--- a/app/Controllers/Auth/LoginController.php
+++ b/app/Controllers/Auth/LoginController.php
@@ -2,11 +2,9 @@
 
 namespace App\Controllers\Auth;
 
-
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
-use \App\Libs\ViewResolver;
 
 class LoginController extends Controller
 {
@@ -28,8 +26,9 @@ class LoginController extends Controller
      *
      * @return void
      */
-    public function __construct(Request $request, ViewResolver $viewResolver){
-        parent::__construct($request,$viewResolver);
+    public function __construct(Request $request)
+    {
+        parent::__construct($request);
 
         $this->middleware('guest', ['except' => 'logout']);
     }
@@ -39,16 +38,18 @@ class LoginController extends Controller
      *
      * @var string
      */
-    public function redirectTo(){
+    public function redirectTo()
+    {
         return route('dashboard.index');
     }
 
     /**
-    *
-    * Returns if email or username is for authentication.
-    */
+     *
+     * Returns if email or username is for authentication.
+     */
 
-    public function username(){
+    public function username()
+    {
         return 'username';
     }
 
@@ -58,18 +59,19 @@ class LoginController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function showLoginForm(){
+    public function showLoginForm()
+    {
 
-        $this->view->title('Welcome');
-        return $this->view->render('auth/login',[
-                                                    'app_name' => \Config::get('app.name'),
-                                                    'admin_logo' => url(\Config::get('horizontcms.admin_logo')),
-                                                ]);
+        return view('auth.login', [
+            'app_name' => \Config::get('app.name'),
+            'admin_logo' => url(\Config::get('horizontcms.admin_logo')),
+        ]);
     }
 
 
 
-    public function logout(Request $request){
+    public function logout(Request $request)
+    {
 
         $this->guard()->logout();
         $request->session()->flush();
@@ -77,6 +79,4 @@ class LoginController extends Controller
 
         return redirect(route('login'));
     }
-
-    
 }

--- a/app/Controllers/Auth/RegisterController.php
+++ b/app/Controllers/Auth/RegisterController.php
@@ -2,11 +2,10 @@
 
 namespace App\Controllers\Auth;
 
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use App\Model\User;
 use Validator;
 use Illuminate\Foundation\Auth\RegistersUsers;
-use \App\Libs\ViewResolver;
 
 class RegisterController extends Controller
 {
@@ -35,19 +34,14 @@ class RegisterController extends Controller
      *
      * @return void
      */
-    public function __construct(ViewResolver $viewResolver)
+    public function __construct()
     {
-
-        $this->view = $viewResolver;
-
         $this->middleware('guest');
-
-        $this->view->title("Register");
     }
 
     public function showRegistrationForm()
     {
-        return $this->view->render('auth/register');
+        return view('auth.register');
     }
 
 

--- a/app/Controllers/Auth/ResetPasswordController.php
+++ b/app/Controllers/Auth/ResetPasswordController.php
@@ -3,11 +3,9 @@
 namespace App\Controllers\Auth;
 
 
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
-use \App\Libs\ViewResolver;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class ResetPasswordController extends Controller
 {
@@ -31,21 +29,20 @@ class ResetPasswordController extends Controller
      *
      * @return void
      */
-    public function __construct(Request $request,ViewResolver $viewResolver)
+    public function __construct(Request $request)
     {
-        $this->view = $viewResolver;
         $this->middleware('guest');
-
     }
 
 
     public function showResetForm(Request $request, $token = null)
     {
-        $this->view->title("Password reset");
-        return $this->view->render('auth/passwords/reset',['token' => $token, 'email' => $request->email,
-                                                            'app_name' => \Config::get('app.name'),
-                                                            'admin_logo' => url(\Config::get('horizontcms.admin_logo')),
-                                                          ]);
+        return view('auth.passwords.reset', [
+            'token' => $token,
+            'email' => $request->email,
+            'app_name' => \Config::get('app.name'),
+            'admin_logo' => url(\Config::get('horizontcms.admin_logo')),
+        ]);
     }
 
 
@@ -69,5 +66,4 @@ class ResetPasswordController extends Controller
 
         $this->guard()->login($user);
     }
-
 }

--- a/app/Controllers/Auth/ResetPasswordController.php
+++ b/app/Controllers/Auth/ResetPasswordController.php
@@ -29,7 +29,7 @@ class ResetPasswordController extends Controller
      *
      * @return void
      */
-    public function __construct(Request $request)
+    public function __construct()
     {
         $this->middleware('guest');
     }

--- a/app/Controllers/BlogpostCategoryController.php
+++ b/app/Controllers/BlogpostCategoryController.php
@@ -4,7 +4,7 @@ namespace App\Controllers;
 
 use App\Controllers\Trait\UploadsImage;
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 
 use App\Model\BlogpostCategory;
 
@@ -22,11 +22,7 @@ class BlogpostCategoryController extends Controller
      */
     public function index()
     {
-
-
-
-        $this->view->title(trans('category.category'));
-        return $this->view->render('blogposts/category/index', [
+        return view('blogposts.category.index', [
             'all_category' => BlogpostCategory::all(),
         ]);
     }
@@ -36,9 +32,7 @@ class BlogpostCategoryController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function create()
-    {
-    }
+    public function create() {}
 
     /**
      * Store a newly created resource in storage.
@@ -56,9 +50,9 @@ class BlogpostCategoryController extends Controller
         $this->uploadImage($blogpost_category);
 
         if ($blogpost_category->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_created_blogpost_category')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_created_blogpost_category')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -70,8 +64,7 @@ class BlogpostCategoryController extends Controller
      */
     public function show(BlogpostCategory $blogpostcategory)
     {
-        $this->view->title(trans('category.category'));
-        return $this->view->render('blogposts.category.view', ['category' => $blogpostcategory]);
+        return view('blogposts.category.view', ['category' => $blogpostcategory]);
     }
 
     /**
@@ -82,9 +75,8 @@ class BlogpostCategoryController extends Controller
      */
     public function edit(BlogpostCategory $blogpostcategory)
     {
-        $this->view->title(trans('blogpost.edit_blogpost'));
 
-        return $this->view->render('blogposts/category/edit', [
+        return view('blogposts.category.edit', [
             'category' => $blogpostcategory,
         ]);
     }
@@ -104,9 +96,9 @@ class BlogpostCategoryController extends Controller
         $this->uploadImage($blogpostcategory);
 
         if ($blogpostcategory->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_updated_blogpost_category')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_updated_blogpost_category')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -120,9 +112,9 @@ class BlogpostCategoryController extends Controller
     {
 
         if ($blogpostcategory->delete()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_deleted_blogpost_category')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_deleted_blogpost_category')]);
         }
 
-        return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 }

--- a/app/Controllers/BlogpostCommentController.php
+++ b/app/Controllers/BlogpostCommentController.php
@@ -3,7 +3,7 @@
 namespace App\Controllers;
 
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 
 use App\Model\BlogpostComment;
 
@@ -33,7 +33,7 @@ class BlogpostCommentController extends Controller
         $blogpost_comment->blogpost_id = $request->input('blogpost_id');
         $blogpost_comment->author()->associate($request->user());
 
-        return $this->redirectToSelf()->withMessage(
+        return redirect()->back()->withMessage(
             $blogpost_comment->save() ? ['success' => trans('message.successfully_created_blogpost_comment')]
                 : ['danger' => trans('message.something_went_wrong')]
         );
@@ -64,7 +64,7 @@ class BlogpostCommentController extends Controller
         $blogpost_comment->author()->associate($this->request->user());
 
 
-        return $this->redirectToSelf()->withMessage(
+        return redirect()->back()->withMessage(
             $blogpost_comment->save() ? ['success' => trans('message.successfully_updated_blogpost_comment')]
                 : ['danger' => trans('message.something_went_wrong')]
         );
@@ -80,7 +80,7 @@ class BlogpostCommentController extends Controller
     {
 
 
-        return $this->redirectToSelf()->withMessage(
+        return redirect()->back()->withMessage(
             $blogpostcomment->delete() ? ['success' => trans('message.successfully_deleted_blogpost_comment')]
                 : ['danger' => trans('message.something_went_wrong')]
         );

--- a/app/Controllers/BlogpostController.php
+++ b/app/Controllers/BlogpostController.php
@@ -4,7 +4,7 @@ namespace App\Controllers;
 
 use App\Controllers\Trait\UploadsImage;
 use \Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use App\Model\Blogpost;
 
 class BlogpostController extends Controller
@@ -24,7 +24,7 @@ class BlogpostController extends Controller
     public function before()
     {
         //TODO Use model path
-		\File::ensureDirectoryExists($this->imagePath . '/thumbs');
+        \File::ensureDirectoryExists($this->imagePath . '/thumbs');
     }
 
     /**
@@ -36,12 +36,11 @@ class BlogpostController extends Controller
     {
         $blogposts = Blogpost::orderBy('id', 'desc')->paginate($this->itemPerPage);
 
-        if($request->wantsJson()){
+        if ($request->wantsJson()) {
             return response()->json($blogposts);
         }
 
-        $this->view->title(trans('blogpost.blogposts'));
-        return $this->view->render('blogposts/index', [
+        return view('blogposts.index', [
             'all_blogposts' =>  $blogposts,
         ]);
     }
@@ -54,8 +53,7 @@ class BlogpostController extends Controller
     public function create()
     {
 
-        $this->view->title(trans('blogpost.new_blogpost'));
-        return $this->view->render('blogposts/form', [
+        return view('blogposts.form', [
             'categories' => \App\Model\BlogpostCategory::all(),
         ]);
     }
@@ -76,8 +74,8 @@ class BlogpostController extends Controller
 
         $this->uploadImage($blogpost);
 
-        return $blogpost->save() ? $this->redirect(route("blogpost.edit", ['blogpost' => $blogpost]))->withMessage(['success' => trans('message.successfully_created_blogpost')])
-            : $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return $blogpost->save() ? redirect(route("blogpost.edit", ['blogpost' => $blogpost]))->withMessage(['success' => trans('message.successfully_created_blogpost')])
+            : redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 
     /**
@@ -88,13 +86,13 @@ class BlogpostController extends Controller
      */
     public function show(Request $request, Blogpost $blogpost)
     {
-    
-        if($request->wantsJson()){
+
+        if ($request->wantsJson()) {
             return response()->json($blogpost);
         }
 
-        $this->view->title(trans('blogpost.view_blogpost'));
-        return $this->view->render('blogposts/view', [
+
+        return view('blogposts.view', [
             'blogpost' => $blogpost,
             'previous_blogpost' => Blogpost::where('id', '<', $blogpost->id)->max('id'),
             'next_blogpost' =>  Blogpost::where('id', '>', $blogpost->id)->min('id'),
@@ -110,9 +108,7 @@ class BlogpostController extends Controller
     public function edit(Blogpost $blogpost)
     {
 
-        $this->view->title(trans('blogpost.edit_blogpost'));
-
-        return $this->view->render('blogposts/form', [
+        return view('blogposts.form', [
             'blogpost' => $blogpost,
             'categories' => \App\Model\BlogpostCategory::all(),
         ]);
@@ -128,19 +124,19 @@ class BlogpostController extends Controller
     public function update(Request $request, Blogpost $blogpost)
     {
 
-	    $blogpost->fill($request->all());
+        $blogpost->fill($request->all());
 
         $blogpost->slug = str_slug($request->input('title', $blogpost->title), "-");
         $blogpost->category_id = $request->input('category_id', $blogpost->category_id);
-        
+
         $blogpost->author()->associate($request->user());
 
         $this->uploadImage($blogpost);
 
         if ($blogpost->save()) {
-            return $this->redirectToSelf()->with('blogpost', $blogpost)->withMessage(['success' => trans('message.successfully_updated_blogpost')]);
+            return redirect()->back()->with('blogpost', $blogpost)->withMessage(['success' => trans('message.successfully_updated_blogpost')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -154,11 +150,10 @@ class BlogpostController extends Controller
     {
 
         if ($blogpost->delete()) {
-            return $this->redirect(route("blogpost.index"))->withMessage(['success' => trans('message.successfully_deleted_blogpost')]);
+            return redirect(route("blogpost.index"))->withMessage(['success' => trans('message.successfully_deleted_blogpost')]);
         }
 
 
-        return $this->redirect(route("blogpost.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect(route("blogpost.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
-
 }

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -2,8 +2,7 @@
 
 namespace App\Controllers;
 
-use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 
 
 class DashboardController extends Controller
@@ -19,21 +18,19 @@ class DashboardController extends Controller
 
         $updater = new \Codedge\Updater\UpdaterManager(app());
 
-        $admin_logo = $this->request->settings['admin_logo'];
+        $admin_logo = request()->settings['admin_logo'];
 
-        $this->view->title(trans('dashboard.title'));
-        return $this->view->render("dashboard/index", [
 
-            'domain' => $this->request->getHost(),
+        return view("dashboard.index", [
+            'domain' => request()->getHost(),
             'server_ip' => isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : "unknown",
-            'client_ip' => $this->request->ip(),
+            'client_ip' => request()->ip(),
             'blogposts'  => \App\Model\Blogpost::count(),
             'users' => \App\Model\User::count(),
             'visits' => \App\Model\Visits::count(),
             'admin_logo' => ($admin_logo != "" && file_exists("storage/images/logos/" . $admin_logo)) ? "storage/images/logos/" . $admin_logo : \Config::get('horizontcms.admin_logo'),
             'disk_space' => @((disk_free_space("/") ?: 1) / (disk_total_space("/") ?: 1)) * 100,
-            'upgrade' => $this->request->settings['auto_upgrade_check'] == 1 && \Auth::user()->hasPermission('upgrade')? $updater->source() : null,
-
+            'upgrade' => request()->settings['auto_upgrade_check'] == 1 && \Auth::user()->hasPermission('upgrade')? $updater->source() : null,
         ]);
     }
 
@@ -44,13 +41,11 @@ class DashboardController extends Controller
 
     public function unauthorized()
     {
-        $this->view->title('Access denied');
-        return $this->view->render('errors/unauthorized');
+        return view('errors.unauthorized');
     }
 
     public function notfound()
     {
-        $this->view->title('Access denied');
-        return $this->view->render('errors/404');
+        return view('errors.404');
     }
 }

--- a/app/Controllers/FileManagerController.php
+++ b/app/Controllers/FileManagerController.php
@@ -2,7 +2,8 @@
 
 namespace App\Controllers;
 
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
 class FileManagerController extends Controller
@@ -13,13 +14,12 @@ class FileManagerController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
 
+        $mode = $request->get('mode');
 
-        $mode = $this->request->get('mode');
-
-        $current_dir = str_replace_first("storage/", "", $this->request->get('path') == NULL ? "" : ltrim($this->request->get('path'), "/"));
+        $current_dir = str_replace_first("storage/", "", $request->get('path') == null ? "" : ltrim($request->get('path'), "/"));
 
         $data = [
             'old_path' => ($current_dir == "" ? "" : $current_dir . "/"),
@@ -37,12 +37,11 @@ class FileManagerController extends Controller
         ];
 
 
-        if ($this->request->ajax()) {
+        if ($request->ajax()) {
             return response()->json($data);
         }
 
-        $this->view->title(trans('File Manager'));
-        return $this->view->render($mode == 'embed' ? 'media/embed' : 'media/fmframe', $data);
+        return view($mode == 'embed' ? 'media.embed' : 'media.fmframe', $data);
     }
 
     /**
@@ -50,51 +49,49 @@ class FileManagerController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function store()
+    public function store(Request $request)
     {
+        if ($request->isMethod('POST')) {
 
+            if ($request->hasFile('up_file')) {
 
-        if ($this->request->isMethod('POST')) {
+                $dir = str_replace("storage/", "", $request->input('dir_path'));
 
-            if ($this->request->hasFile('up_file')) {
-
-                $dir = str_replace("storage/", "", $this->request->input('dir_path'));
-
-                foreach ($this->request->up_file as $file) {
+                foreach ($request->up_file as $file) {
                     if (!\Security::isExecutable($file)) {
                         $images[] = $file->store($dir);
                     }
                 }
 
-                if ($this->request->ajax()) {
+                if ($request->ajax()) {
                     return response()->json(['success' => 'Files uploaded successfully!', 'uploadedFileNames' => $images]);
                 }
 
-                return $this->redirectToSelf()->withMessage(['success' => 'Files uploaded successfully!']);
+                return redirect()->back()->withMessage(['success' => 'Files uploaded successfully!']);
             } else {
 
-                if ($this->request->ajax()) {
+                if ($request->ajax()) {
                     return response()->json(['danger' => 'Could not upload files!']);
                 }
 
-                return $this->redirectToSelf()->withMessage(['danger' => 'Could not upload files!']);
+                return redirect()->back()->withMessage(['danger' => 'Could not upload files!']);
             }
         }
 
-        if ($this->request->ajax()) {
+        if ($request->ajax()) {
             return response()->json(['warning' => 'Only POST method allowed!']);
         }
 
-        return $this->redirectToSelf()->withMessage(['warning' => 'Only POST method allowed!']);
+        return redirect()->back()->withMessage(['warning' => 'Only POST method allowed!']);
     }
 
 
     public function download()
     {
 
-        if ($this->request->has('file')) {
+        if (request()->has('file')) {
 
-            $file = $this->request->input('file');
+            $file = request()->input('file');
 
             $headers = [
                 'Content-Type' => 'application/*',
@@ -103,38 +100,38 @@ class FileManagerController extends Controller
             return response()->download($file, basename($file), $headers);
         }
 
-        return $this->redirectToSelf()->withMessage(['warning' => 'Bad request!']);
+        return redirect()->back()->withMessage(['warning' => 'Bad request!']);
     }
 
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $this->request
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
     public function newFolder()
     {
 
-        if ($this->request->isMethod('POST')) {
+        if (request()->isMethod('POST')) {
 
-            $directory = "storage/" . str_replace("storage/", "", $this->request->input('dir_path')) . "/" . $this->request->input('new_folder_name');
+            $directory = "storage/" . str_replace("storage/", "", request()->input('dir_path')) . "/" . request()->input('new_folder_name');
 
             if (!file_exists($directory)) {
                 \File::makeDirectory($directory, $mode = 0777, true, true);
 
-                if ($this->request->ajax()) {
+                if (request()->ajax()) {
                     return response()->json(['success' => 'Folder created successfully!']);
                 }
 
-                return $this->redirectToSelf()->withMessage(['success' => 'Folder created successfully!']);
+                return redirect()->back()->withMessage(['success' => 'Folder created successfully!']);
             } else {
 
-                if ($this->request->ajax()) {
+                if (request()->ajax()) {
                     return response()->json(['danger' => 'Folder already exists!']);
                 }
 
-                return $this->redirectToSelf()->withMessage(['danger' => 'Folder already exists!']);
+                return redirect()->back()->withMessage(['danger' => 'Folder already exists!']);
             }
         }
     }
@@ -149,39 +146,38 @@ class FileManagerController extends Controller
     public function destroy()
     {
 
-
-        $toDelete = str_replace("storage/", "", $this->request->input('file'));
+        $toDelete = str_replace("storage/", "", request()->input('file'));
 
         if (!file_exists('storage/' . $toDelete)) {
-            if ($this->request->ajax()) {
+            if (request()->ajax()) {
                 return response()->json(['warning' => trans("File " . $toDelete . " doesn't exists")]);
             }
 
-            return $this->redirectToSelf()->withMessage(['warning' => trans("File " . $toDelete . " doesn't exists")]);
+            return redirect()->back()->withMessage(['warning' => trans("File " . $toDelete . " doesn't exists")]);
         }
 
 
         if (!is_dir('storage/' . $toDelete) && Storage::delete($toDelete)) {
 
-            if ($this->request->ajax()) {
+            if (request()->ajax()) {
                 return response()->json(['success' => trans('File deleted successfully')]);
             }
 
-            return $this->redirectToSelf()->withMessage(['success' => trans('File deleted successfully')]);
+            return redirect()->back()->withMessage(['success' => trans('File deleted successfully')]);
         } else if (is_dir('storage/' . $toDelete) && Storage::deleteDirectory($toDelete)) {
 
-            if ($this->request->ajax()) {
+            if (request()->ajax()) {
                 return response()->json(['success' => trans('Directory deleted successfully')]);
             }
 
-            return $this->redirectToSelf()->withMessage(['success' => trans('Directory deleted successfully')]);
+            return redirect()->back()->withMessage(['success' => trans('Directory deleted successfully')]);
         } else {
 
-            if ($this->request->ajax()) {
+            if (request()->ajax()) {
                 return response()->json(['danger' => trans('message.something_went_wrong')]);
             }
 
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -190,11 +186,11 @@ class FileManagerController extends Controller
     public function upload()
     {
 
-        if ($this->request->isMethod('POST')) {
+        if (request()->isMethod('POST')) {
 
-            if ($this->request->hasFile('upload')) {
+            if (request()->hasFile('upload')) {
 
-                $image = $this->request->upload->store('images/' . $this->request->input('module'));
+                $image = request()->upload->store('images/' . request()->input('module'));
 
                 if ($image) {
                     // if($this->request->ajax()){
@@ -217,21 +213,21 @@ class FileManagerController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $this->request
+     * @param  \Illuminate\Http\Request  $request
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
     public function rename()
     {
 
-        $new_file = trim($this->request->input('new_file'), "/");
+        $new_file = trim(request()->input('new_file'), "/");
 
-        if (!\Security::isExecutable($new_file) && \Storage::move($this->request->input('old_file'), $new_file)) {
-            if ($this->request->ajax()) {
+        if (!\Security::isExecutable($new_file) && \Storage::move(request()->input('old_file'), $new_file)) {
+            if (request()->ajax()) {
                 return response()->json(['success' => trans('File successfully renamed!')]);
             }
         } else {
-            if ($this->request->ajax()) {
+            if (request()->ajax()) {
                 return response()->json(['danger' => trans('message.something_went_wrong')]);
             }
         }

--- a/app/Controllers/FileManagerController.php
+++ b/app/Controllers/FileManagerController.php
@@ -14,12 +14,12 @@ class FileManagerController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request)
+    public function index()
     {
 
-        $mode = $request->get('mode');
+        $mode = request()->get('mode');
 
-        $current_dir = str_replace_first("storage/", "", $request->get('path') == null ? "" : ltrim($request->get('path'), "/"));
+        $current_dir = str_replace_first("storage/", "", request()->get('path') == null ? "" : ltrim(request()->get('path'), "/"));
 
         $data = [
             'old_path' => ($current_dir == "" ? "" : $current_dir . "/"),
@@ -37,7 +37,7 @@ class FileManagerController extends Controller
         ];
 
 
-        if ($request->ajax()) {
+        if (request()->ajax()) {
             return response()->json($data);
         }
 
@@ -49,28 +49,28 @@ class FileManagerController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store()
     {
-        if ($request->isMethod('POST')) {
+        if (request()->isMethod('POST')) {
 
-            if ($request->hasFile('up_file')) {
+            if (request()->hasFile('up_file')) {
 
-                $dir = str_replace("storage/", "", $request->input('dir_path'));
+                $dir = str_replace("storage/", "", request()->input('dir_path'));
 
-                foreach ($request->up_file as $file) {
+                foreach (request()->up_file as $file) {
                     if (!\Security::isExecutable($file)) {
                         $images[] = $file->store($dir);
                     }
                 }
 
-                if ($request->ajax()) {
+                if (request()->ajax()) {
                     return response()->json(['success' => 'Files uploaded successfully!', 'uploadedFileNames' => $images]);
                 }
 
                 return redirect()->back()->withMessage(['success' => 'Files uploaded successfully!']);
             } else {
 
-                if ($request->ajax()) {
+                if (request()->ajax()) {
                     return response()->json(['danger' => 'Could not upload files!']);
                 }
 
@@ -78,7 +78,7 @@ class FileManagerController extends Controller
             }
         }
 
-        if ($request->ajax()) {
+        if (request()->ajax()) {
             return response()->json(['warning' => 'Only POST method allowed!']);
         }
 

--- a/app/Controllers/HeaderImageController.php
+++ b/app/Controllers/HeaderImageController.php
@@ -4,7 +4,7 @@ namespace App\Controllers;
 
 use App\Controllers\Trait\UploadsImage;
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 
 use App\Model\HeaderImage;
 
@@ -33,8 +33,7 @@ class HeaderImageController extends Controller
             return response()->json($activeImages);
         }
 
-        $this->view->title(trans('Header Images'));
-        return $this->view->render('media/header_images', [
+        return view('media.header_images', [
             'slider_images' => $activeImages,
             'slider_disabled' => HeaderImage::inactive()->orderBy('order','ASC')->get(),
         ]);
@@ -57,9 +56,9 @@ class HeaderImageController extends Controller
         $header_image->active = 1;
 
         if ($header_image->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -70,12 +69,12 @@ class HeaderImageController extends Controller
         $header_image->active = 0;
 
         if ($header_image->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
 
-        return $this->redirectToSelf();
+        return redirect()->back();
     }
 
     /**
@@ -92,12 +91,10 @@ class HeaderImageController extends Controller
         $this->uploadImage($header_image);
 
         if ($header_image->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
-        } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
-        }
-
-        return $this->redirectToSelf();
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
+        } 
+        
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 
     /**
@@ -135,12 +132,11 @@ class HeaderImageController extends Controller
         $headerimage->author()->associate($request->user());
 
         if($headerimage->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
-        } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_added_headerimage')]);
         }
 
-        return $this->redirectToSelf();
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
+
     }
 
 
@@ -154,10 +150,9 @@ class HeaderImageController extends Controller
     {
 
         if ($headerimage->delete()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_deleted_blogpost')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_deleted_blogpost')]);
         }
 
-
-        return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 }

--- a/app/Controllers/PageController.php
+++ b/app/Controllers/PageController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Libs\Controller;
 use App\Model\Page;
 
+// TODO
 class PageController extends Controller
 {
 
@@ -38,10 +39,10 @@ class PageController extends Controller
             return response()->json($pages);
         }
 
+        // TODO
         $this->view->js('resources/js/dragndrop.js');
 
-        $this->view->title(trans('page.pages'));
-        return $this->view->render('pages/index', [
+        return view('pages.index', [
             'all_pages' => $pages,
             'visible_pages' => Page::where('visibility', 1)->count(),
             'home_page' => Page::find($this->request->settings['home_page']),
@@ -55,11 +56,10 @@ class PageController extends Controller
      */
     public function create(Request $request)
     {
-        
+        // TODO
         $this->view->js('resources/js/pages.js');
 
-        $this->view->title(trans('page.new_page'));
-        return $this->view->render('pages/form', [
+        return view('pages.form', [
             'all_page' => Page::all(),
             'page_templates' => (new \App\Libs\Theme($request->settings['theme']))->templates(),
         ]);
@@ -85,9 +85,9 @@ class PageController extends Controller
         $this->uploadImage($page);
 
         if ($page->save()) {
-            return $this->redirect(route("page.edit", ['page' => $page]))->withMessage(['success' => trans('message.successfully_created_page')]);
+            return redirect(route("page.edit", ['page' => $page]))->withMessage(['success' => trans('message.successfully_created_page')]);
         } else {
-            return $this->redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -103,8 +103,7 @@ class PageController extends Controller
             return response()->json($page);
         }
 
-        $this->view->title(trans('page.view_page'));
-        return $this->view->render('pages/view', ['page' => $page]);
+        return view('pages.view', ['page' => $page]);
     }
 
     /**
@@ -115,12 +114,10 @@ class PageController extends Controller
      */
     public function edit(Request $request, Page $page)
     {
-
+        // TODO
         $this->view->js('resources/js/pages.js');
 
-        $this->view->title(trans('page.edit_page'));
-
-        return $this->view->render('pages/form', [
+        return view('pages.form', [
             'page' => $page,
             'all_page' => Page::all(),
             'page_templates' => (new \App\Libs\Theme($request->settings['theme']))->templates(),
@@ -148,9 +145,9 @@ class PageController extends Controller
         $this->uploadImage($page);
 
         if ($page->save()) {
-            return $this->redirect(route("page.edit", ['page' => $page]))->withMessage(['success' => trans('message.successfully_updated_page')]);
+            return redirect(route("page.edit", ['page' => $page]))->withMessage(['success' => trans('message.successfully_updated_page')]);
         } else {
-            return $this->redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -159,9 +156,9 @@ class PageController extends Controller
     {
 
         if (\App\Model\Settings::where("setting", "home_page")->update(['value' => $id])) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_set_homepage')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_set_homepage')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -176,11 +173,11 @@ class PageController extends Controller
     {
 
         if ($page->delete()) {
-            return $this->redirect(route("page.index"))->withMessage(['success' => trans('message.successfully_deleted_page')]);
+            return redirect(route("page.index"))->withMessage(['success' => trans('message.successfully_deleted_page')]);
         }
 
 
-        return $this->redirect(route("page.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect(route("page.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 
 
@@ -191,7 +188,7 @@ class PageController extends Controller
 
         try {
 
-            $order = json_decode($this->request->input("order"), true);
+            $order = json_decode(request()->input("order"), true);
 
             for ($i = 0; $i < count($order); $i++) {
                 $page = \App\Model\Page::find($order[$i]);

--- a/app/Controllers/PageController.php
+++ b/app/Controllers/PageController.php
@@ -4,10 +4,9 @@ namespace App\Controllers;
 
 use App\Controllers\Trait\UploadsImage;
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use App\Model\Page;
 
-// TODO
 class PageController extends Controller
 {
 
@@ -39,13 +38,10 @@ class PageController extends Controller
             return response()->json($pages);
         }
 
-        // TODO
-        $this->view->js('resources/js/dragndrop.js');
-
         return view('pages.index', [
             'all_pages' => $pages,
             'visible_pages' => Page::where('visibility', 1)->count(),
-            'home_page' => Page::find($this->request->settings['home_page']),
+            'home_page' => Page::find($request->settings['home_page']),
         ]);
     }
 
@@ -56,8 +52,6 @@ class PageController extends Controller
      */
     public function create(Request $request)
     {
-        // TODO
-        $this->view->js('resources/js/pages.js');
 
         return view('pages.form', [
             'all_page' => Page::all(),
@@ -84,11 +78,11 @@ class PageController extends Controller
 
         $this->uploadImage($page);
 
-        if ($page->save()) {
+        if($page->save()) {
             return redirect(route("page.edit", ['page' => $page]))->withMessage(['success' => trans('message.successfully_created_page')]);
-        } else {
-            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
-        }
+        } 
+            
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 
     /**
@@ -114,8 +108,6 @@ class PageController extends Controller
      */
     public function edit(Request $request, Page $page)
     {
-        // TODO
-        $this->view->js('resources/js/pages.js');
 
         return view('pages.form', [
             'page' => $page,
@@ -146,9 +138,9 @@ class PageController extends Controller
 
         if ($page->save()) {
             return redirect(route("page.edit", ['page' => $page]))->withMessage(['success' => trans('message.successfully_updated_page')]);
-        } else {
-            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
-        }
+        } 
+
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 
 
@@ -157,9 +149,9 @@ class PageController extends Controller
 
         if (\App\Model\Settings::where("setting", "home_page")->update(['value' => $id])) {
             return redirect()->back()->withMessage(['success' => trans('message.successfully_set_homepage')]);
-        } else {
-            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
-        }
+        } 
+
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 
 
@@ -176,12 +168,8 @@ class PageController extends Controller
             return redirect(route("page.index"))->withMessage(['success' => trans('message.successfully_deleted_page')]);
         }
 
-
         return redirect(route("page.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
-
-
-
 
     public function reorder()
     {

--- a/app/Controllers/PluginController.php
+++ b/app/Controllers/PluginController.php
@@ -22,15 +22,11 @@ class PluginController extends Controller
      */
     public function index()
     {
-
-        $this->view->title(trans('Applications'));
-        return $this->view->render('plugin/index', [
+        return view('plugin.index', [
             'all_plugin' => collect(\File::directories(base_path() . DIRECTORY_SEPARATOR . "plugins"))->map(function ($dir) {
                 return new \App\Model\Plugin(str_replace(base_path() . DIRECTORY_SEPARATOR . "plugins" . DIRECTORY_SEPARATOR, "", $dir));
             }),
-
             'zip_enabled' => class_exists('ZipArchive'),
-
         ]);
     }
 
@@ -52,9 +48,6 @@ class PluginController extends Controller
      */
     public function onlinestore()
     {
-
-        $this->view->title(trans('App center'));
-
         $repo_status = true;
 
         try {
@@ -66,7 +59,7 @@ class PluginController extends Controller
 
 
 
-        return $this->view->render('plugin/store', ['online_plugins' => $plugins, 'repo_status' => $repo_status]);
+        return view('plugin.store', ['online_plugins' => $plugins, 'repo_status' => $repo_status]);
     }
 
 
@@ -86,12 +79,12 @@ class PluginController extends Controller
 
             if (file_exists("plugins/" . $plugin_name)) {
                 @\Storage::delete("framework" . DIRECTORY_SEPARATOR . "temp" . DIRECTORY_SEPARATOR . $plugin_name . ".zip");
-                return $this->redirectToSelf()->withMessage(['success' => trans('Succesfully downloaded ' . $plugin_name)]);
+                return redirect()->back()->withMessage(['success' => trans('Succesfully downloaded ' . $plugin_name)]);
             } else {
-                return $this->redirectToSelf()->withMessage(['danger' => trans('Could not extract the plugin: ' . $plugin_name . "")]);
+                return redirect()->back()->withMessage(['danger' => trans('Could not extract the plugin: ' . $plugin_name . "")]);
             }
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('Could not download the plugin: ' . $plugin_name . "")]);
+            return redirect()->back()->withMessage(['danger' => trans('Could not download the plugin: ' . $plugin_name . "")]);
         }
     }
 
@@ -110,7 +103,7 @@ class PluginController extends Controller
             $plugin = new \App\Model\Plugin($plugin_name);
 
             if (!$plugin->isCompatibleWithCore()) {
-                return $this->redirectToSelf()->withMessage(['warning' => trans('plugin.not_compatible_with_core', ['min_core_ver' => $plugin->getRequiredCoreVersion()])]);
+                return redirect()->back()->withMessage(['warning' => trans('plugin.not_compatible_with_core', ['min_core_ver' => $plugin->getRequiredCoreVersion()])]);
             }
 
 
@@ -141,17 +134,16 @@ class PluginController extends Controller
 
             $plugin->save();
 
-            foreach(\App\Model\UserRole::all() as $role){
-                if($role->isAdminRole()){
+            foreach (\App\Model\UserRole::all() as $role) {
+                if ($role->isAdminRole()) {
                     $role->addRight(str_slug($plugin->root_dir));
                     $role->save();
                 }
             }
 
-
-            return $this->redirectToSelf()->withMessage(['success' => trans('Succesfully installed ' . $plugin_name)]);
+            return redirect()->back()->withMessage(['success' => trans('Succesfully installed ' . $plugin_name)]);
         } catch (\Exception $e) {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong') . " " . $e->getMessage()]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong') . " " . $e->getMessage()]);
         }
     }
 
@@ -168,9 +160,9 @@ class PluginController extends Controller
         $plugin->active = 1;
 
         if ($plugin->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('Succesfully activated ' . $plugin_name)]);
+            return redirect()->back()->withMessage(['success' => trans('Succesfully activated ' . $plugin_name)]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -188,9 +180,9 @@ class PluginController extends Controller
 
 
         if ($plugin->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('Succesfully deactivated ' . $plugin_name)]);
+            return redirect()->back()->withMessage(['success' => trans('Succesfully deactivated ' . $plugin_name)]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -223,20 +215,19 @@ class PluginController extends Controller
                 \Storage::disk('plugins')->deleteDirectory($plugin);
             }
         } catch (\Exception $e) {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong') . " " . $e->getMessage()]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong') . " " . $e->getMessage()]);
         }
 
-
-        return $this->redirectToSelf()->withMessage(['success' => trans('Succesfully deleted the plugin!')]);
+        return redirect()->back()->withMessage(['success' => trans('Succesfully deleted the plugin!')]);
     }
 
 
     public function upload()
     {
 
-        if ($this->request->hasFile('up_file')) {
+        if (request()->hasFile('up_file')) {
 
-            $file_name = $this->request->up_file[0]->store('framework/temp');
+            $file_name = request()->up_file[0]->store('framework/temp');
         }
 
         $zip = new \ZipArchive;
@@ -246,9 +237,9 @@ class PluginController extends Controller
 
             \Storage::delete("storage/" . $file_name);
 
-            return $this->redirectToSelf()->withMessage(['success' => trans('Succesfully uploaded the plugin!')]);
+            return redirect()->back()->withMessage(['success' => trans('Succesfully uploaded the plugin!')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 }

--- a/app/Controllers/PluginController.php
+++ b/app/Controllers/PluginController.php
@@ -3,7 +3,7 @@
 namespace App\Controllers;
 
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 
 
 class PluginController extends Controller
@@ -56,8 +56,6 @@ class PluginController extends Controller
             $plugins = [];
             $repo_status = false;
         }
-
-
 
         return view('plugin.store', ['online_plugins' => $plugins, 'repo_status' => $repo_status]);
     }

--- a/app/Controllers/ScheduleController.php
+++ b/app/Controllers/ScheduleController.php
@@ -3,7 +3,7 @@
 namespace App\Controllers;
 
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use App\Model\ScheduledTask;
 
 class ScheduleController extends Controller
@@ -16,9 +16,7 @@ class ScheduleController extends Controller
      */
     public function index()
     {
-
-        $this->view->title("Schedules");
-        return $this->view->render('settings/schedules', [
+        return view('settings.schedules', [
             'commands' => rescue(fn() => \Artisan::all(), fn() => []),
             'scheduled_tasks' => \App\Model\ScheduledTask::all(),
         ]);
@@ -41,9 +39,9 @@ class ScheduleController extends Controller
         $task->active = 1;
 
         if ($task->save()) {
-            return $this->redirectToSelf()->withMessage(['succes' => trans('Succesfully scheduled a task!')]);
+            return redirect()->back()->withMessage(['succes' => trans('Succesfully scheduled a task!')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -73,9 +71,9 @@ class ScheduleController extends Controller
 
 
         if ($schedule->delete()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('Successfully deleted the task!')]);
+            return redirect()->back()->withMessage(['success' => trans('Successfully deleted the task!')]);
         }
 
-        return $this->redirect(route("settings.show", ['setting' => 'schedules']))->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect(route("settings.show", ['setting' => 'schedules']))->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 }

--- a/app/Controllers/ScheduleController.php
+++ b/app/Controllers/ScheduleController.php
@@ -19,6 +19,7 @@ class ScheduleController extends Controller
         return view('settings.schedules', [
             'commands' => rescue(fn() => \Artisan::all(), fn() => []),
             'scheduled_tasks' => \App\Model\ScheduledTask::all(),
+            'scheduler' => \Settings::where('setting','scheduler')->first()
         ]);
     }
 

--- a/app/Controllers/SearchController.php
+++ b/app/Controllers/SearchController.php
@@ -3,43 +3,29 @@
 namespace App\Controllers;
 
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use App\Libs\SearchEngine;
-use \App\Libs\ViewResolver;
-
 
 class SearchController extends Controller
 {
-
-    private $search_engine;
-
-    public function __construct(Request $request, ViewResolver $viewResolver, SearchEngine $search_engine)
-    {
-        parent::__construct($request, $viewResolver);
-
-        $this->search_engine = $search_engine;
-    }
-
     /**
      * Display a listing of the resource.
      *
      * @return \Illuminate\Http\Response
      */
-    public function show(Request $request)
+    public function show(Request $request, SearchEngine $search_engine)
     {
         $search_key = "%" . $request->input('search') . "%";
 
-        $this->search_engine->registerModel(\App\Model\Blogpost::class);
-        $this->search_engine->registerModel(\App\Model\User::class);
-        $this->search_engine->registerModel(\App\Model\Page::class);
+        $search_engine->registerModel(\App\Model\Blogpost::class);
+        $search_engine->registerModel(\App\Model\User::class);
+        $search_engine->registerModel(\App\Model\Page::class);
 
-        $this->search_engine->executeSearch($search_key);
+        $search_engine->executeSearch($search_key);
 
-        $this->view->title(trans('search.title'));
-
-        return $this->view->render("search/index", [
+        return view("search.index", [
             'search_for' => $request->input('search'),
-            'search_engine' => $this->search_engine,
+            'search_engine' => $search_engine,
             'files' => [],
         ]);
     }

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -3,7 +3,7 @@
 namespace App\Controllers;
 
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 
 use App\Model\Settings;
 use \Jackiedo\LogReader\Facades\LogReader;
@@ -25,7 +25,7 @@ class SettingsController extends Controller
             Settings::updateOrCreate(['setting' => $key], ['value' => $value, 'more' => 1]);
         }
 
-        return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_saved_settings')]);
+        return redirect()->back()->withMessage(['success' => trans('message.successfully_saved_settings')]);
     }
 
     private function getSettingsPanels()
@@ -51,9 +51,7 @@ class SettingsController extends Controller
      */
     public function index()
     {
-
-        $this->view->title(trans('settings.settings'));
-        return $this->view->render('settings/index', [
+        return view('settings.index', [
             'panels' => $this->getSettingsPanels(),
         ]);
     }
@@ -78,10 +76,7 @@ class SettingsController extends Controller
      */
     public function website()
     {
-
-
-        $this->view->title(trans('settings.settings'));
-        return $this->view->render('settings/website', [
+        return view('settings.website', [
             'available_logos' => array_slice(scandir("storage/images/logos"), 2),
             'user_roles' => \App\Model\UserRole::all(),
         ]);
@@ -95,10 +90,7 @@ class SettingsController extends Controller
      */
     public function adminarea()
     {
-
-
-        $this->view->title(trans('settings.settings'));
-        return $this->view->render('settings/adminarea', [
+        return view('settings.adminarea', [
             'languages' => ['en' => 'English', 'hu' => 'Magyar'],
             'available_logos' => array_slice(scandir("storage/images/logos"), 2),
             'dateFormats' => ['Y.m.d H:i:s', 'Y-m-d H:i:s', 'Y. M. d H:i:s', 'd-m-Y H:i:s', 'd/m/Y H:i:s', 'm/d/Y H:i:s'],
@@ -107,9 +99,8 @@ class SettingsController extends Controller
 
     public function server()
     {
-        $this->view->title("Server");
-        return $this->view->render('settings/server', [
-            'server' => $this->request->server(),
+        return view('settings.server', [
+            'server' => request()->server(),
         ]);
     }
 
@@ -133,8 +124,7 @@ class SettingsController extends Controller
                 $tables = [['name' => 'Could not get table informations']];
         }
 
-        $this->view->title(trans('settings.database'));
-        return $this->view->render('settings/database', [
+        return view('settings.database', [
             'tables' =>  $tables,
 
         ]);
@@ -146,17 +136,16 @@ class SettingsController extends Controller
     {
 
 
-        if ($this->request->isMethod('POST')) {
+        if (request()->isMethod('POST')) {
 
-            foreach ($this->request->all() as $key => $value) {
+            foreach (request()->all() as $key => $value) {
                 Settings::where('setting', '=', "social_link_" . $key)->update(['value' => $value]);
             }
 
-            return $this->redirectToSelf()->withMessage(['success' => trans('message.successfully_saved_settings')]);
+            return redirect()->back()->withMessage(['success' => trans('message.successfully_saved_settings')]);
         }
 
-        $this->view->title("SocialMedia");
-        return $this->view->render('settings/socialmedia', [
+        return view('settings.socialmedia', [
             'all_socialmedia' => \SocialLink::all(),
         ]);
     }
@@ -179,9 +168,7 @@ class SettingsController extends Controller
         }
 
         // dd($entries);
-
-        $this->view->title("Log files");
-        return $this->view->render('settings/log', [
+        return view('settings.log', [
             'all_files' => $files->reverse(),
             'entries' => $entries->reverse(),
             'entry_number' => $entries->count(),

--- a/app/Controllers/UpgradeController.php
+++ b/app/Controllers/UpgradeController.php
@@ -3,8 +3,7 @@
 namespace App\Controllers;
 
 use Composer\Semver\Comparator;
-use App\Libs\Controller;
-use App\Libs\ViewResolver;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 
 class UpgradeController extends Controller
@@ -12,9 +11,9 @@ class UpgradeController extends Controller
 
     private $updateManager = null;
 
-    public function __construct(Request $request,ViewResolver $viewResolver, \Codedge\Updater\UpdaterManager $updater){
+    public function __construct(Request $request, \Codedge\Updater\UpdaterManager $updater){
 
-        parent::__construct($request, $viewResolver);
+        parent::__construct($request);
 
         $this->updateManager = $updater;
     }
@@ -35,8 +34,7 @@ class UpgradeController extends Controller
 
         $available_list = $releases->filter(fn($release) => Comparator::greaterThan($release['tag_name'], 'v'.$this->updateManager->source()->getVersionInstalled()));
 
-        $this->view->title(trans('settings.settings'));
-        return $this->view->render('upgrade/index', [
+        return view('upgrade.index', [
             'current_version' => $this->updateManager->source()->getVersionInstalled(),
             'available_list' => $available_list,
             'upgrade_list' => $releases->filter(fn($release) => Comparator::lessThanOrEqualTo($release['tag_name'], $this->updateManager->source()->getVersionInstalled()))->slice(0,5),

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -4,7 +4,7 @@ namespace App\Controllers;
 
 use App\Controllers\Trait\UploadsImage;
 use Illuminate\Http\Request;
-use App\Libs\Controller;
+use Illuminate\Routing\Controller;
 use App\Model\User;
 
 class UserController extends Controller
@@ -33,10 +33,7 @@ class UserController extends Controller
      */
     public function index()
     {
-
-
-        $this->view->title(trans('user.users'));
-        return $this->view->render('users/index', [
+        return view('users.index', [
             'all_users' => User::paginate($this->itemPerPage),
             'active_users' => User::where('active', 1)->count(),
         ]);
@@ -49,10 +46,8 @@ class UserController extends Controller
      */
     public function create()
     {
-
-        $this->view->title(trans('user.create_user'));
-        return $this->view->render('users/form', [
-            'current_user' => $this->request->user(),
+        return view('users.form', [
+            'current_user' => request()->user(),
             'role_options' => \App\Model\UserRole::all()
         ]);
     }
@@ -77,9 +72,9 @@ class UserController extends Controller
 
         if ($user->save()) {
 
-            return $this->redirect(route("user.edit", ['user' => $user]))->withMessage(['success' => trans('message.successfully_created_user')]);
+            return redirect(route("user.edit", ['user' => $user]))->withMessage(['success' => trans('message.successfully_created_user')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -91,9 +86,7 @@ class UserController extends Controller
      */
     public function show(User $user)
     {
-
-        $this->view->title(trans('user.view_user'));
-        return $this->view->render('users/view', [
+        return view('users.view', [
             'user' => $user,
             'previous_user' => User::where('id', '<', $user->id)->max('id'),
             'next_user' =>  User::where('id', '>', $user->id)->min('id'),
@@ -108,10 +101,8 @@ class UserController extends Controller
      */
     public function edit(User $user)
     {
-
-        $this->view->title(trans('user.edit_user'));
-        return $this->view->render('users/form', [
-            'current_user' => $this->request->user(),
+        return view('users.form', [
+            'current_user' => request()->user(),
             'user' => $user,
             'role_options' => \App\Model\UserRole::all(),
         ]);
@@ -137,9 +128,9 @@ class UserController extends Controller
         $this->uploadImage($user);
 
         if ($user->save()) {
-            return $this->redirect(route("user.edit", ['user' => $user]))->withMessage(['success' => trans('message.successfully_updated_user')]);
+            return redirect(route("user.edit", ['user' => $user]))->withMessage(['success' => trans('message.successfully_updated_user')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -156,9 +147,9 @@ class UserController extends Controller
         $user->active = 1;
 
         if ($user->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('User successfully activated!')]);
+            return redirect()->back()->withMessage(['success' => trans('User successfully activated!')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -173,10 +164,10 @@ class UserController extends Controller
     {
 
         if ($user->delete()) {
-            return $this->redirect(route("user.index"))->withMessage(['success' => trans('message.successfully_deleted_user')]);
+            return redirect(route("user.index"))->withMessage(['success' => trans('message.successfully_deleted_user')]);
         }
 
 
-        return $this->redirect(route("user.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect(route("user.index"))->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 }

--- a/app/Controllers/UserRoleController.php
+++ b/app/Controllers/UserRoleController.php
@@ -3,8 +3,7 @@
 namespace App\Controllers;
 
 use Illuminate\Http\Request;
-use App\Libs\Controller;
-use App\Http\Requests;
+use Illuminate\Routing\Controller;
 use App\Model\UserRole;
 
 class UserRoleController extends Controller
@@ -12,9 +11,7 @@ class UserRoleController extends Controller
 
     public function index()
     {
-
-        $this->view->title('User roles');
-        return $this->view->render('users/roles/index', [
+        return view('users.roles.index', [
             'all_user_roles' => \App\Model\UserRole::all(),
             'permission_list' => $this->getPermissionList(),
         ]);
@@ -27,10 +24,7 @@ class UserRoleController extends Controller
      */
     public function create()
     {
-
-
-        $this->view->title('Create role');
-        return $this->view->render('users/roles/create', [
+        return view('users.roles.create', [
             'permission_list' => $this->getPermissionList(),
         ]);
     }
@@ -80,9 +74,9 @@ class UserRoleController extends Controller
         $role->permission = 0;
 
         if ($role->save()) {
-            return $this->redirect(route('userrole.index'))->withMessage(['success' => trans('User role created succesfully!')]);
+            return redirect(route('userrole.index'))->withMessage(['success' => trans('User role created succesfully!')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -116,12 +110,12 @@ class UserRoleController extends Controller
     public function update(UserRole $userrole)
     {
 
-        $userrole->rights = array_keys($this->request->except('_token'));
+        $userrole->rights = array_keys(request()->except('_token'));
 
         if ($userrole->save()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('Rights saved succesfully!')]);
+            return redirect()->back()->withMessage(['success' => trans('Rights saved succesfully!')]);
         } else {
-            return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+            return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
         }
     }
 
@@ -135,9 +129,9 @@ class UserRoleController extends Controller
     {
 
         if ($userrole->delete()) {
-            return $this->redirectToSelf()->withMessage(['success' => trans('User role deleted succesfully!')]);
+            return redirect()->back()->withMessage(['success' => trans('User role deleted succesfully!')]);
         }
 
-        return $this->redirectToSelf()->withMessage(['danger' => trans('message.something_went_wrong')]);
+        return redirect()->back()->withMessage(['danger' => trans('message.something_went_wrong')]);
     }
 }

--- a/app/Helpers/Html.php
+++ b/app/Helpers/Html.php
@@ -1,21 +1,34 @@
 <?php
 
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 class Html {
 
-
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public static function cssFile($file){
 		return "<link rel='stylesheet' type='text/css' media='all' href='".$file."' />";
 	}
 
-
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public static function jsFile($file){
 		return "<script src='".$file."' type='text/javascript' charset='utf-8'></script>";
 	}
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public static function meta($property,$content){
 		return "<meta property='".$property."' content='".$content."' />";
 	}
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public static function favicon($string){
 
 		$ext = pathinfo($string, PATHINFO_EXTENSION);

--- a/app/Helpers/Security.php
+++ b/app/Helpers/Security.php
@@ -1,11 +1,20 @@
 <?php
 
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 class Security{
 
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     public static function vulnerableExtensions(){
         return '/^.*\.('.implode('|',["php","php5","php7","phar","phtml","htaccess"]).')$/i';
     }
 
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     public static function isExecutable($file){
         return preg_match(self::vulnerableExtensions(), strtolower($file));
     }

--- a/app/Helpers/UrlManager.php
+++ b/app/Helpers/UrlManager.php
@@ -9,6 +9,9 @@
 class UrlManager
 {
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public static function seo_url($string)
 	{
 
@@ -28,7 +31,9 @@ class UrlManager
 		}
 	}
 
-
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public static function http_protocol($string)
 	{
 

--- a/app/Libs/Controller.php
+++ b/app/Libs/Controller.php
@@ -9,6 +9,9 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use App\Libs\ViewResolver;
 use Illuminate\Http\Request;
 
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 abstract class Controller extends BaseController {
 	
     protected $request;

--- a/app/Libs/Controller.php
+++ b/app/Libs/Controller.php
@@ -14,21 +14,37 @@ use Illuminate\Http\Request;
  */
 abstract class Controller extends BaseController {
 	
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     protected $request;
+
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     protected $view;
 
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     public function __construct(Request $request,ViewResolver $viewResolver){
     	$this->request = $request;	
 
         $this->view = $viewResolver;
     }
 
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     public function redirect($location){
     	return redirect($location);
     }
 
+    /**
+     * @deprecated deprecated since version 1.0.0
+     */
     public function redirectToSelf(){
         return redirect()->back();
     }

--- a/app/Libs/ThemeEngine.php
+++ b/app/Libs/ThemeEngine.php
@@ -2,7 +2,7 @@
 
 namespace App\Libs;
 
-class ThemeEngine{
+class ThemeEngine {
 
 	protected $theme;
 	protected $page_template = 'index';

--- a/app/Libs/ViewResolver.php
+++ b/app/Libs/ViewResolver.php
@@ -15,7 +15,6 @@ class ViewResolver
 	public function __construct()
 	{
 		$this->data['title'] = null;
-		$this->data['meta'][] = ['viewport', 'width=device-width, initial-scale=1'];
 		$this->data['css'] = Config::get('horizontcms.css');
 		$this->data['js'] = Config::get('horizontcms.js');
 	}
@@ -42,10 +41,5 @@ class ViewResolver
 	{
 		$this->data['js'][] = $file;
 	}
-
-
-	public function meta($name, $content)
-	{
-		$this->data['meta'][] = [$name, $content];
-	}
+	
 }

--- a/app/Libs/ViewResolver.php
+++ b/app/Libs/ViewResolver.php
@@ -10,8 +10,14 @@ use Config;
 class ViewResolver
 {
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public $data = [];
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public function __construct()
 	{
 		$this->data['title'] = null;
@@ -19,24 +25,34 @@ class ViewResolver
 		$this->data['js'] = Config::get('horizontcms.js');
 	}
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public function title($title)
 	{
 		$this->data['title'] = $title;
 	}
 
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public function render($view_file, array $data = [])
 	{
 
 		return view($view_file, array_merge($this->data, $data));
 	}
 
-
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public function css($file)
 	{
 		$this->data['css'][] = $file;
 	}
 
-
+	/**
+	 * @deprecated deprecated since version 1.0.0
+	 */
 	public function js($file)
 	{
 		$this->data['js'][] = $file;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -33,9 +33,10 @@ class AppServiceProvider extends ServiceProvider
                 $this->app->register(\Laravel\Dusk\DuskServiceProvider::class);
         }
 
-        // TODO Use these
-        // View::share('css', \Config::get('horizontcms.css'));
-        // View::share('js', \Config::get('horizontcms.js'));
+
+        View::share('title', "");
+        View::share('css', \Config::get('horizontcms.css'));
+        View::share('js', \Config::get('horizontcms.js'));
         
     }
 

--- a/app/Providers/PluginServiceProvider.php
+++ b/app/Providers/PluginServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Libs\ViewResolver;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;

--- a/app/View/auth/login.blade.php
+++ b/app/View/auth/login.blade.php
@@ -1,4 +1,7 @@
-@extends('layout')
+@extends('layout', [
+    'title' => 'Welcome'
+])
+
 <div class='jumbotron'>
     <div class='container my-5'>
         <div class="row">

--- a/app/View/auth/passwords/email.blade.php
+++ b/app/View/auth/passwords/email.blade.php
@@ -1,4 +1,7 @@
-@extends('layout')
+@extends('layout', [
+    'title' => "Password reset"
+])
+
 
 <div class='jumbotron'>
     <div class='container my-5'>

--- a/app/View/auth/passwords/reset.blade.php
+++ b/app/View/auth/passwords/reset.blade.php
@@ -1,4 +1,6 @@
-@extends('layout')
+@extends('layout', [
+    'title' => "Forgot password"
+])
 
 @section('content')
     <div class='jumbotron'>

--- a/app/View/auth/register.blade.php
+++ b/app/View/auth/register.blade.php
@@ -1,4 +1,6 @@
-@extends('layout')
+@extends('layout', [
+    'title' => 'Register'
+])
 
 @section('content')
 <div class="container">

--- a/app/View/blogposts/category/edit.blade.php
+++ b/app/View/blogposts/category/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('blogpost.edit_blogpost')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/blogposts/category/index.blade.php
+++ b/app/View/blogposts/category/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('category.category')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/blogposts/category/view.blade.php
+++ b/app/View/blogposts/category/view.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('category.category')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/blogposts/form.blade.php
+++ b/app/View/blogposts/form.blade.php
@@ -1,4 +1,6 @@
-@extends('layout')
+@extends('layout', [
+    'title' => isset($blogpost)? trans('blogpost.edit_blogpost') : trans('blogpost.new_blogpost') 
+])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/blogposts/index.blade.php
+++ b/app/View/blogposts/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('blogpost.blogposts')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/blogposts/view.blade.php
+++ b/app/View/blogposts/view.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('blogpost.view_blogpost')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/dashboard/index.blade.php
+++ b/app/View/dashboard/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('dashboard.title')])
 
 @section('content')
     <div class='container main-container' id='dashboard'>

--- a/app/View/errors/404.blade.php
+++ b/app/View/errors/404.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Not found')])
 
 @section('content')
 <div class="p-5">

--- a/app/View/errors/unauthorized.blade.php
+++ b/app/View/errors/unauthorized.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Access denied')])
 
 @section('content')
 <div class="p-5">

--- a/app/View/install/index.blade.php
+++ b/app/View/install/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans("Install")])
 
 @section('content')
     <div>

--- a/app/View/install/step1.blade.php
+++ b/app/View/install/step1.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans("Install")])
 
 @section('content')
     <div class='jumbotron'>

--- a/app/View/install/step2.blade.php
+++ b/app/View/install/step2.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans("Install")])
 
 @section('content')
     <div class='jumbotron'>

--- a/app/View/install/step3.blade.php
+++ b/app/View/install/step3.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans("Install")])
 
 @section('content')
     <div class='jumbotron'>

--- a/app/View/install/step4.blade.php
+++ b/app/View/install/step4.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans("Install")])
 
 @section('content')
     <div class='jumbotron'>

--- a/app/View/layout.blade.php
+++ b/app/View/layout.blade.php
@@ -29,7 +29,7 @@
 
 </head>
 
-<body @if (Auth::user()) style="padding-top: 5rem;" @endif>
+<body @style(["padding-top: 5rem;" => Auth::user()])>
 
     <div id="hcms">
 

--- a/app/View/media/embed.blade.php
+++ b/app/View/media/embed.blade.php
@@ -2,7 +2,7 @@
 
 <head>
     <base href="{{ config('app.url') }}" />
-    <title>{{ $title }} - {{ config('app.name') }}</title>
+    <title>{{ trans('File Manager') }} - {{ config('app.name') }}</title>
     <meta name="csrf-token" content="{{ csrf_token() }}" />
     <link rel="shortcut icon" type="image/png" href="resources/images/icons/favicon16.png" />
 

--- a/app/View/media/fmframe.blade.php
+++ b/app/View/media/fmframe.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('File Manager')])
 
 @section('content')
 

--- a/app/View/media/header_images.blade.php
+++ b/app/View/media/header_images.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Header Images')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/pages/form.blade.php
+++ b/app/View/pages/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layout', ['title' => isset($page)? trans('page.edit_page') : trans('page.new_page')])
+@extends('layout', ['title' => isset($page)? trans('page.edit_page') : trans('page.new_page'), 'js' => array_merge($js, ['resources/js/pages.js'])])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/pages/form.blade.php
+++ b/app/View/pages/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => isset($page)? trans('page.edit_page') : trans('page.new_page')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/pages/index.blade.php
+++ b/app/View/pages/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout', ['title' => trans('page.pages'), 'js' => ['resources/js/dragndrop.js'] ])
+@extends('layout', ['title' => trans('page.pages'), 'js' => array_merge($js, ['resources/js/dragndrop.js']) ])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/pages/index.blade.php
+++ b/app/View/pages/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('page.pages'), 'js' => ['resources/js/dragndrop.js'] ])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/plugin/index.blade.php
+++ b/app/View/plugin/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Applications')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/plugin/store.blade.php
+++ b/app/View/plugin/store.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('App center')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/search/index.blade.php
+++ b/app/View/search/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('search.title')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/settings/adminarea.blade.php
+++ b/app/View/settings/adminarea.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('settings.settings')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/settings/database.blade.php
+++ b/app/View/settings/database.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('settings.database')])
 
 @section('content')
     <div class='container'>

--- a/app/View/settings/index.blade.php
+++ b/app/View/settings/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('settings.settings')])
 
 @section('content')
     <div class="container main-container">

--- a/app/View/settings/log.blade.php
+++ b/app/View/settings/log.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans("Log files")])
 
 @section('content')
     <div class='container card'>

--- a/app/View/settings/schedules.blade.php
+++ b/app/View/settings/schedules.blade.php
@@ -16,6 +16,12 @@
                         'data' => 'data-bs-toggle=modal data-bs-target=.new_task',
                     ],
                 ],
+                'buttons_right' => [
+                    [
+                        'label' => "Scheduler: ".$scheduler->value,
+                        'class' => 'badge '.(\Carbon\Carbon::now()->diffInMinutes($scheduler->updated_at) > 5)? 'text-bg-danger' : 'text-bg-success',
+                    ],
+                ],
             ])
 
             <div class="card-body">

--- a/app/View/settings/schedules.blade.php
+++ b/app/View/settings/schedules.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Schedules')])
 
 @section('content')
     <div class='container'>

--- a/app/View/settings/server.blade.php
+++ b/app/View/settings/server.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', [ 'title' => trans('Server') ])
 
 @section('content')
     <div class='container'>

--- a/app/View/settings/socialmedia.blade.php
+++ b/app/View/settings/socialmedia.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('SocialMedia')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/settings/website.blade.php
+++ b/app/View/settings/website.blade.php
@@ -1,4 +1,5 @@
-@extends('layout')
+@extends('layout', [ 'title' => trans('settings.settings')])
+
 @section('content')
     <div class='container main-container'>
 

--- a/app/View/theme/index.blade.php
+++ b/app/View/theme/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('theme.themes')])
 
 @section('content')
     <div class='container'>

--- a/app/View/theme/options.blade.php
+++ b/app/View/theme/options.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('theme.options')])
 
 @section('content')
     <div class='container'>

--- a/app/View/theme/store.blade.php
+++ b/app/View/theme/store.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Theme center')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/upgrade/index.blade.php
+++ b/app/View/upgrade/index.blade.php
@@ -1,4 +1,6 @@
-@extends('layout')
+@extends('layout', [
+    'title' => trans('settings.settings')
+])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/users/form.blade.php
+++ b/app/View/users/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => isset($user)? trans('user.edit_user') : trans('user.create_user')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/users/index.blade.php
+++ b/app/View/users/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('user.users')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/users/roles/create.blade.php
+++ b/app/View/users/roles/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('Create role')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/users/roles/index.blade.php
+++ b/app/View/users/roles/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('User roles')])
 
 @section('content')
     <div class='container main-container'>

--- a/app/View/users/view.blade.php
+++ b/app/View/users/view.blade.php
@@ -1,4 +1,4 @@
-@extends('layout')
+@extends('layout', ['title' => trans('user.view_user')])
 
 @section('content')
     <div class='container main-container'>

--- a/config/horizontcms.php
+++ b/config/horizontcms.php
@@ -2,7 +2,7 @@
 
 return [
 
-	'version' => 'v1.1.0',
+	'version' => 'v1.2.0',
 
 	'backend_prefix' => env('HCMS_ADMIN_PREFIX','admin'),
 

--- a/resources/tests/CreatesApplication.php
+++ b/resources/tests/CreatesApplication.php
@@ -11,7 +11,7 @@ trait CreatesApplication
      */
     public function createApplication()
     {
-        $app = require __DIR__.'/../../bootstrap/app.php';
+        $app = require __DIR__ . '/../../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
 

--- a/resources/tests/ModelFactory.php
+++ b/resources/tests/ModelFactory.php
@@ -1,8 +1,10 @@
 <?php
 
-class ModelFactory{
+class ModelFactory
+{
 
-    public static function createUser($active = false){
+    public static function createUser($active = false)
+    {
 
         static $password;
 
@@ -11,20 +13,19 @@ class ModelFactory{
         $name = $name_array[array_rand($name_array)];
 
         $user = new \App\Model\User(
-        [
-            'name' => $name,
-            'username' => str_replace(" ",".",strtolower($name." ".str_random(3))),
-            'slug' => str_slug($name),
-            'email' => strtolower(str_slug($name)."@".str_random(5).".com"),
-            'password' =>  $password ?: $password = bcrypt('secret'),
-            'remember_token' => str_random(10),
-            'active' => $active? 1 : 0,
-        ]);
+            [
+                'name' => $name,
+                'username' => str_replace(" ", ".", strtolower($name . " " . str_random(3))),
+                'slug' => str_slug($name),
+                'email' => strtolower(str_slug($name) . "@" . str_random(5) . ".com"),
+                'password' =>  $password ?: $password = bcrypt('secret'),
+                'remember_token' => str_random(10),
+                'active' => $active ? 1 : 0,
+            ]
+        );
 
         $user->save();
 
         return $user;
     }
-
-
 }

--- a/resources/tests/SeleniumTest.php
+++ b/resources/tests/SeleniumTest.php
@@ -1,8 +1,9 @@
 <?php
 
-class SeleniumTest extends PHPUnit_Extensions_Selenium2TestCase{
+class SeleniumTest extends PHPUnit_Extensions_Selenium2TestCase
+{
 
-   /* protected $captureScreenshotOnFailure = TRUE;
+    /* protected $captureScreenshotOnFailure = TRUE;
     protected $screenshotPath = '/var/www/localhost/htdocs/screenshots';
     protected $screenshotUrl = 'http://localhost/screenshots';*/
     protected $browser = 'chrome';
@@ -11,16 +12,14 @@ class SeleniumTest extends PHPUnit_Extensions_Selenium2TestCase{
     protected function setUp()
     {
 
-    	$this->setBrowser($this->browser);
+        $this->setBrowser($this->browser);
         $this->setBrowserUrl('http://localhost/');
-   
 
-    	$app = require __DIR__.'/../../bootstrap/app.php';
+
+        $app = require __DIR__ . '/../../bootstrap/app.php';
 
         $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
     }
-
-
 }

--- a/resources/tests/TestCase.php
+++ b/resources/tests/TestCase.php
@@ -16,7 +16,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      */
     public function createApplication()
     {
-        $app = require __DIR__.'/../../bootstrap/app.php';
+        $app = require __DIR__ . '/../../bootstrap/app.php';
 
         $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 

--- a/resources/tests/acceptance/LoginBrowserTest.php
+++ b/resources/tests/acceptance/LoginBrowserTest.php
@@ -2,20 +2,13 @@
 
 require_once("resources/tests/SeleniumTest.php");
 
-class LoginBrowserTest extends SeleniumTest{
-
-
+class LoginBrowserTest extends SeleniumTest
+{
 
     public function testTitle()
     {
 
-        $this->url('/'.\Config::get('horizontcms.backend_prefix'));
+        $this->url('/' . \Config::get('horizontcms.backend_prefix'));
         $this->assertEquals('Welcome - HorizontCMS', $this->title());
     }
-
-
-
-
-
-
 }

--- a/resources/tests/functional/LoginTest.php
+++ b/resources/tests/functional/LoginTest.php
@@ -8,52 +8,44 @@ class LoginTest extends TestCase
 {
 
 	/** @before */
-	public function checkIfCMSIsInstalled(){
+	public function checkIfCMSIsInstalled()
+	{
 
-		if(!\App\HorizontCMS::isInstalled()){
+		if (!\App\HorizontCMS::isInstalled()) {
 			echo "HorizontCMS is not installed! Tests are stopped!";
 			exit;
 		}
-
-    }
-
+	}
 
 	/** @before */
-    public function createTestUser(){
-        
-        if(!isset($this->user)){
-	        $this->user = factory(\App\Model\User::class)->create([
-	        	 'role_id'=> '6',
-	        	 'password' => 'testpass123'
-	        ]);
-	    }
+	public function createTestUser()
+	{
 
-    }
+		if (!isset($this->user)) {
+			$this->user = factory(\App\Model\User::class)->create([
+				'role_id' => '6',
+				'password' => 'testpass123'
+			]);
+		}
+	}
 
+	public function testOpenLoginPage()
+	{
 
+		$this->visit(\Config::get('horizontcms.backend_prefix'))
+			->seePageIs(\Config::get('horizontcms.backend_prefix') . "/login")
+			->see('HorizontCMS')
+			->see('Closer to the web');
+	}
 
-    public function testOpenLoginPage()
-    {
-	
-	    $this->visit(\Config::get('horizontcms.backend_prefix'))
-	         ->seePageIs(\Config::get('horizontcms.backend_prefix')."/login")
-	         ->see('HorizontCMS')
-             ->see('Closer to the web');
-                
-    }
+	public function testInvalidCredentials()
+	{
 
-
-    public function testInvalidCredentials(){
-	    	
-	    $this->visit(\Config::get('horizontcms.backend_prefix'))     
-	    	 ->type($this->user->username,'username')
-	         ->type('wrongpassword','password')
-	         ->press('submit_login')
-	         ->seePageIs(\Config::get('horizontcms.backend_prefix')."/login")
-	         ->see('These credentials do not match our records.');
-
-
-    }
-
-
+		$this->visit(\Config::get('horizontcms.backend_prefix'))
+			->type($this->user->username, 'username')
+			->type('wrongpassword', 'password')
+			->press('submit_login')
+			->seePageIs(\Config::get('horizontcms.backend_prefix') . "/login")
+			->see('These credentials do not match our records.');
+	}
 }

--- a/resources/tests/integration/BlogpostControllerTest.php
+++ b/resources/tests/integration/BlogpostControllerTest.php
@@ -4,93 +4,93 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
-class BlogpostControllerTest extends TestCase{
+class BlogpostControllerTest extends TestCase
+{
 
-    public function testIndexAction(){
+    public function testIndexAction()
+    {
 
         \Event::fake();
 
-        $request = Request::create('/admin/blogpost/index', 'GET',[]);
+        $request = Request::create('/admin/blogpost/index', 'GET', []);
 
-        $controller = new \App\Controllers\BlogpostController($request, new \App\Libs\ViewResolver());
+        $controller = new \App\Controllers\BlogpostController($request);
 
         $responseView = $controller->index(null);
 
-        $this->assertInstanceOf(\Illuminate\View\View::class,$responseView);
+        $this->assertInstanceOf(\Illuminate\View\View::class, $responseView);
 
         $this->assertEquals('blogposts.index', $responseView->name());
 
 
         $this->assertTrue(isset($responseView->getData()['number_of_blogposts']));
         $this->assertTrue(isset($responseView->getData()['all_blogposts']));
-        $this->assertInstanceOf(\App\Model\Blogpost::class,$responseView->getData()['all_blogposts'][0]);
+        $this->assertInstanceOf(\App\Model\Blogpost::class, $responseView->getData()['all_blogposts'][0]);
     }
 
 
-    public function testShowAction(){
+    public function testShowAction()
+    {
 
         $idToTest = 1;
 
         \Event::fake();
 
-        $request = Request::create('/admin/blogpost/show', 'POST',[]);
+        $request = Request::create('/admin/blogpost/show', 'POST', []);
 
-        $controller = new \App\Controllers\BlogpostController($request, new \App\Libs\ViewResolver());
+        $controller = new \App\Controllers\BlogpostController($request);
 
         $responseView = $controller->show($idToTest);
 
-        $this->assertInstanceOf(\Illuminate\View\View::class,$responseView);
+        $this->assertInstanceOf(\Illuminate\View\View::class, $responseView);
 
         $this->assertEquals('blogposts.view', $responseView->name());
 
 
         $this->assertTrue(isset($responseView->getData()['blogpost']));
-      //  $this->assertFalse(isset($responseView->getData()['previous_blogpost'])); //We checking the first blogpost
-       // $this->assertTrue(isset($responseView->getData()['next_blogpost']));
-        $this->assertInstanceOf(\App\Model\Blogpost::class,$responseView->getData()['blogpost']);
-        
-        $this->assertEquals($idToTest,$responseView->getData()['blogpost']->id);
+        //  $this->assertFalse(isset($responseView->getData()['previous_blogpost'])); //We checking the first blogpost
+        // $this->assertTrue(isset($responseView->getData()['next_blogpost']));
+        $this->assertInstanceOf(\App\Model\Blogpost::class, $responseView->getData()['blogpost']);
+
+        $this->assertEquals($idToTest, $responseView->getData()['blogpost']->id);
     }
 
 
-    public function testCreateAction(){
-        
+    public function testCreateAction()
+    {
+
         \Event::fake();
 
-        $requestGet = Request::create('/admin/blogpost/show', 'GET',[]);
+        $requestGet = Request::create('/admin/blogpost/show', 'GET', []);
 
-        $controller = new \App\Controllers\BlogpostController($requestGet, new \App\Libs\ViewResolver());
+        $controller = new \App\Controllers\BlogpostController($requestGet);
 
         $response = $controller->create();
 
         $this->assertEquals('blogposts.create', $response->name());
         $this->assertTrue(isset($response->getData()['categories']));
-        $this->assertInstanceOf(\App\Model\BlogpostCategory::class,$response->getData()['categories'][0]);
+        $this->assertInstanceOf(\App\Model\BlogpostCategory::class, $response->getData()['categories'][0]);
 
-        $requestPost = Request::create('/admin/blogpost/show', 'POST',[
+        $requestPost = Request::create('/admin/blogpost/show', 'POST', [
             'title' => 'AutomatedTest',
             'category_id' => 1,
             'summary' => 'This is the summary of the test blogpost',
             'text' => 'A very long blogpost text',
             'active' => 1
         ]);
-        
+
         $user =  ModelFactory::createUser(true);
 
         $requestPost->setUserResolver(function () use ($user) {
             return $user;
         });
 
-        $controller = new \App\Controllers\BlogpostController($requestPost, new \App\Libs\ViewResolver());
+        $controller = new \App\Controllers\BlogpostController($requestPost);
 
         $response = $controller->create();
 
-        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class,$response);    
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
 
-        $this->assertEquals(['success' => trans('message.successfully_created_blogpost')],$response->getSession()->get('message'));
-        
+        $this->assertEquals(['success' => trans('message.successfully_created_blogpost')], $response->getSession()->get('message'));
     }
-
-
-
 }

--- a/resources/tests/unit/AbstractControllerTest.php
+++ b/resources/tests/unit/AbstractControllerTest.php
@@ -1,6 +1,8 @@
 <?php
 
-
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 class AbstractControllerImplementation extends \App\Libs\Controller
 {
 
@@ -10,7 +12,9 @@ class AbstractControllerImplementation extends \App\Libs\Controller
     }
 }
 
-
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 class AbstractControllerTest extends TestCase
 {
 

--- a/resources/tests/unit/AbstractControllerTest.php
+++ b/resources/tests/unit/AbstractControllerTest.php
@@ -1,21 +1,25 @@
 <?php
 
 
-class AbstractControllerImplementation extends \App\Libs\Controller{
+class AbstractControllerImplementation extends \App\Libs\Controller
+{
 
-    public function getViewAttribute() {
+    public function getViewAttribute()
+    {
         return $this->view;
     }
-
 }
 
 
 class AbstractControllerTest extends TestCase
 {
 
+    protected $requestMock;
+    protected $viewMock;
 
     /** @before */
-    public function mockRequest(){
+    public function mockRequest()
+    {
 
         $this->requestMock = \Mockery::mock(\Illuminate\Http\Request::class)->makePartial();
 
@@ -25,42 +29,34 @@ class AbstractControllerTest extends TestCase
 
     public function testControllerCreation()
     {
-      
-
-        $controller = new AbstractControllerImplementation($this->requestMock,$this->viewMock);
-    
-        $this->assertInstanceOf(\App\Libs\Controller::class,$controller);
 
 
+        $controller = new AbstractControllerImplementation($this->requestMock, $this->viewMock);
+
+        $this->assertInstanceOf(\App\Libs\Controller::class, $controller);
     }
 
-    public function testControllerRedirectMethods(){
+    public function testControllerRedirectMethods()
+    {
 
 
         $location = "test/test";
 
-        $controller = new AbstractControllerImplementation($this->requestMock,$this->viewMock);
+        $controller = new AbstractControllerImplementation($this->requestMock, $this->viewMock);
 
-        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class,$controller->redirect($location));
-        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class,$controller->redirectToSelf());
-        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class,$controller->insideLink($location));
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $controller->redirect($location));
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $controller->redirectToSelf());
 
-        $this->assertEquals($this->baseUrl."/".$location,$controller->redirect($location)->getTargetUrl());
-        $this->assertEquals($this->baseUrl."/".\Config::get("horizontcms.backend_prefix")."/".$location,$controller->insideLink($location)->getTargetUrl());
-
+        $this->assertEquals($this->baseUrl . "/" . $location, $controller->redirect($location)->getTargetUrl());
     }
 
-    public function testIfVariablesSet(){
+    public function testIfVariablesSet()
+    {
 
-         $controller = new AbstractControllerImplementation($this->requestMock,$this->viewMock);
+        $controller = new AbstractControllerImplementation($this->requestMock, $this->viewMock);
 
-         $this->assertInstanceOf(\Illuminate\Http\Request::class,$controller->request);
+        $this->assertInstanceOf(\Illuminate\Http\Request::class, $controller->request);
 
-         $this->assertInstanceOf(\App\Libs\ViewResolver::class,$controller->getViewAttribute());
+        $this->assertInstanceOf(\App\Libs\ViewResolver::class, $controller->getViewAttribute());
     }
-
-
 }
-
-
-

--- a/resources/tests/unit/AppTest.php
+++ b/resources/tests/unit/AppTest.php
@@ -16,32 +16,27 @@ class AppTest extends TestCase
 
 
         $this->assertInstanceOf(\App\HorizontCMS::class, $this->app);
-
-
     }
 
 
-    public function testAppRootDir(){
+    public function testAppRootDir()
+    {
 
-        $this->assertEquals($this->app->publicPath(),getcwd().DIRECTORY_SEPARATOR);
-
+        $this->assertEquals($this->app->publicPath(), getcwd() . DIRECTORY_SEPARATOR);
     }
 
 
-    public function testIsInstalled(){
+    public function testIsInstalled()
+    {
 
-        if(file_exists(base_path(".env")) || env("INSTALLED","")!=""){
+        if (file_exists(base_path(".env")) || env("INSTALLED", "") != "") {
 
             $this->assertTrue($this->app->isInstalled());
-            $this->assertNotNull('array',$this->app->plugins);
-
-        }else{
+            $this->assertNotNull('array', $this->app->plugins);
+        } else {
 
             $this->assertFalse($this->app->isInstalled());
             $this->assertNull($this->app->plugins);
-
         }
-
     }
-
 }

--- a/resources/tests/unit/ExceptionHandlerTest.php
+++ b/resources/tests/unit/ExceptionHandlerTest.php
@@ -7,6 +7,9 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class ExceptionHandler extends TestCase
 {
 
+    private $requestMock;
+    private $exceptionHandler;
+
     /** @before */
     public function instantiateExceptionHandler(){
 

--- a/resources/tests/unit/ExceptionHandlerTest.php
+++ b/resources/tests/unit/ExceptionHandlerTest.php
@@ -11,7 +11,8 @@ class ExceptionHandler extends TestCase
     private $exceptionHandler;
 
     /** @before */
-    public function instantiateExceptionHandler(){
+    public function instantiateExceptionHandler()
+    {
 
         $this->requestMock = \Mockery::mock(\Illuminate\Http\Request::class)->makePartial();
         $this->requestMock->headers = new \Symfony\Component\HttpFoundation\HeaderBag([]);
@@ -19,51 +20,39 @@ class ExceptionHandler extends TestCase
         $this->exceptionHandler = new \App\Exceptions\Handler($this->createMock(\Illuminate\Contracts\Container\Container::class));
     }
 
-    public function testRenderAuthorizationException(){
-        $response = $this->exceptionHandler->render($this->requestMock, new \Illuminate\Auth\Access\AuthorizationException('Unauthorized') );
+    public function testRenderAuthorizationException()
+    {
+        $response = $this->exceptionHandler->render($this->requestMock, new \Illuminate\Auth\Access\AuthorizationException('Unauthorized'));
 
-        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class,$response);
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
     }
 
-    
-    public function testRenderAuthenticationException(){
-        
-        $response = $this->exceptionHandler->render($this->requestMock, new \Illuminate\Auth\AuthenticationException('Unauthenticated') );
 
-        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class,$response);
+    public function testRenderAuthenticationException()
+    {
+
+        $response = $this->exceptionHandler->render($this->requestMock, new \Illuminate\Auth\AuthenticationException('Unauthenticated'));
+
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
 
         $this->requestMock->headers->set('Accept', 'application/json');
         $this->requestMock->headers->set('Content-Type', 'application/json');
         $this->requestMock->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->exceptionHandler->render($this->requestMock, new \Illuminate\Auth\AuthenticationException('Unauthenticated') );
+        $response = $this->exceptionHandler->render($this->requestMock, new \Illuminate\Auth\AuthenticationException('Unauthenticated'));
 
-        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class,$response);
-        
+        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
-    public function testRenderAllExceptions(){
-        $response = $this->exceptionHandler->render($this->requestMock, new \Exception('Any exception') );
+    public function testRenderAllExceptions()
+    {
+        $response = $this->exceptionHandler->render($this->requestMock, new \Exception('Any exception'));
 
-        $this->assertInstanceOf(\Illuminate\Http\Response::class,$response);
-        
+        $this->assertInstanceOf(\Illuminate\Http\Response::class, $response);
     }
 
     /* TODO test dontReport */
-   /* public function testReport(){
+    /* public function testReport(){
         $response = $this->exceptionHandler->report(new \Exception('Any exception'));
     }*/
-
-
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/resources/tests/unit/Middleware/AdminMiddlewareTest.php
+++ b/resources/tests/unit/Middleware/AdminMiddlewareTest.php
@@ -22,9 +22,9 @@ class AdminMiddlewareTest extends TestCase
 
         $middleware = new \App\Http\Middleware\AdminMiddleware;
 
-        $response = $middleware->handle($request, function () { });
+        $response = $middleware->handle($request, function () {});
 
-        $this->assertEquals(302, $response->getStatusCode()); 
+        $this->assertEquals(302, $response->getStatusCode());
     }
 
 
@@ -50,7 +50,7 @@ class AdminMiddlewareTest extends TestCase
 
         $this->assertEquals(null, $response);
     }
-    
+
 
     /** @test */
     public function testNonActiveAdminsAreRedirected()
@@ -69,9 +69,8 @@ class AdminMiddlewareTest extends TestCase
 
         $middleware = new \App\Http\Middleware\AdminMiddleware;
 
-        $response = $middleware->handle($request, function () { });
+        $response = $middleware->handle($request, function () {});
 
-        $this->assertEquals(302, $response->getStatusCode()); 
+        $this->assertEquals(302, $response->getStatusCode());
     }
-
 }

--- a/resources/tests/unit/Middleware/InstallerMiddlewareTest.php
+++ b/resources/tests/unit/Middleware/InstallerMiddlewareTest.php
@@ -15,23 +15,22 @@ class InstallerMiddlewareTest extends TestCase
 
         $middleware = new \App\Http\Middleware\InstallerMiddleware;
 
-        $response = $middleware->handle($request, function () { });
+        $response = $middleware->handle($request, function () {});
 
-        $this->assertNull($response); 
+        $this->assertNull($response);
     }
 
     /** @test */
     public function testInstallerIsNotAvailableAfterInstalled()
-        {
-            $request = \Request::create('/admin/install', 'GET');
-    
-            $middleware = new \App\Http\Middleware\InstallerMiddleware;
-    
-            $response = $middleware->handle($request, function () { });
-    
-            $this->assertNotNull($response);
-            $this->assertEquals($response->getStatusCode(),302); 
-            $this->assertEquals($response->headers->get('Location'),\Config::get('app.url').'/admin/login');
-        }
+    {
+        $request = \Request::create('/admin/install', 'GET');
 
+        $middleware = new \App\Http\Middleware\InstallerMiddleware;
+
+        $response = $middleware->handle($request, function () {});
+
+        $this->assertNotNull($response);
+        $this->assertEquals($response->getStatusCode(), 302);
+        $this->assertEquals($response->headers->get('Location'), \Config::get('app.url') . '/admin/login');
+    }
 }

--- a/resources/tests/unit/Middleware/SettingsMiddlewareTest.php
+++ b/resources/tests/unit/Middleware/SettingsMiddlewareTest.php
@@ -7,16 +7,15 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class SettingsMiddlewareTest extends TestCase
 {
-     /** @test */
-     public function testSettingsAreSet()
-     {
-         $request = new Request;
- 
-         $middleware = new \App\Http\Middleware\SettingsMiddleware;
+    /** @test */
+    public function testSettingsAreSet()
+    {
+        $request = new Request;
 
-         $middleware->handle($request, function ($req) {
-             $this->assertNotNull($req->settings);
-         });
-     }
+        $middleware = new \App\Http\Middleware\SettingsMiddleware;
 
+        $middleware->handle($request, function ($req) {
+            $this->assertNotNull($req->settings);
+        });
+    }
 }

--- a/resources/tests/unit/PluginModelTest.php
+++ b/resources/tests/unit/PluginModelTest.php
@@ -7,6 +7,8 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class PluginModelTest extends TestCase
 {
 
+    private $plugin;
+
     private $dummyName = "TestPlugin";
 
     private function getDummyInfo(){

--- a/resources/tests/unit/PluginModelTest.php
+++ b/resources/tests/unit/PluginModelTest.php
@@ -11,7 +11,8 @@ class PluginModelTest extends TestCase
 
     private $dummyName = "TestPlugin";
 
-    private function getDummyInfo(){
+    private function getDummyInfo()
+    {
         $info = new \stdClass();
         $info->name = $this->dummyName;
         $info->version = "1.0";
@@ -25,20 +26,22 @@ class PluginModelTest extends TestCase
     }
 
 
-    protected function setUp() : void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->plugin = new \App\Model\Plugin($this->dummyName);
     }
 
 
-    public function testPluginInitiation(){
-        
-        $this->assertInstanceOf(\App\Model\Plugin::class,$this->plugin);
+    public function testPluginInitiation()
+    {
 
+        $this->assertInstanceOf(\App\Model\Plugin::class, $this->plugin);
     }
 
 
-    public function testInfoUsage(){
+    public function testInfoUsage()
+    {
 
 
         $this->assertFalse($this->plugin->hasInfo());
@@ -47,52 +50,53 @@ class PluginModelTest extends TestCase
 
         $this->assertTrue($this->plugin->hasInfo());
 
-        $this->assertEquals($this->plugin->getInfo("name"),$this->dummyName);
+        $this->assertEquals($this->plugin->getInfo("name"), $this->dummyName);
 
-        $this->assertEquals($this->plugin->getInfo("version"),$this->getDummyInfo()->version);
+        $this->assertEquals($this->plugin->getInfo("version"), $this->getDummyInfo()->version);
 
-        $this->assertEquals($this->plugin->getInfo("requires"),$this->getDummyInfo()->requires);
-
+        $this->assertEquals($this->plugin->getInfo("requires"), $this->getDummyInfo()->requires);
     }
 
-    public function testRootDirSetter(){
+    public function testRootDirSetter()
+    {
 
         $this->plugin->setRootDir($this->dummyName);
-        $this->assertEquals($this->plugin->root_dir,$this->dummyName);
+        $this->assertEquals($this->plugin->root_dir, $this->dummyName);
     }
 
 
-    public function testAllGetter(){
+    public function testAllGetter()
+    {
 
 
         $this->plugin->setAllInfo($this->getDummyInfo());
 
         $this->assertEquals($this->plugin->getName(), $this->dummyName);
-        $this->assertEquals($this->plugin->getNamespaceFor("controller"),"\Plugin\\".$this->dummyName."\\App\\Controller\\");
-        $this->assertEquals($this->plugin->getSlug(),namespace_to_slug($this->dummyName));
-        $this->assertEquals($this->plugin->getPath(),"plugins".DIRECTORY_SEPARATOR.$this->dummyName.DIRECTORY_SEPARATOR);
+        $this->assertEquals($this->plugin->getNamespaceFor("controller"), "\Plugin\\" . $this->dummyName . "\\App\\Controller\\");
+        $this->assertEquals($this->plugin->getSlug(), namespace_to_slug($this->dummyName));
+        $this->assertEquals($this->plugin->getPath(), "plugins" . DIRECTORY_SEPARATOR . $this->dummyName . DIRECTORY_SEPARATOR);
         //$this->plugin->getDatabaseFilesPath();
         //$this->plugin->getIcon();
-        $this->assertEquals($this->plugin->getShortCode(), "{[".$this->dummyName."]}");
-        $this->assertEquals($this->plugin->getRegisterClass(),"\Plugin\\".$this->dummyName."\Register");
+        $this->assertEquals($this->plugin->getShortCode(), "{[" . $this->dummyName . "]}");
+        $this->assertEquals($this->plugin->getRegisterClass(), "\Plugin\\" . $this->dummyName . "\Register");
 
-        $this->assertEquals($this->plugin->getRequirements(),$this->getDummyInfo()->requires);
-        $this->assertEquals($this->plugin->getRequiredCoreVersion(),$this->getDummyInfo()->requires->core);
-
+        $this->assertEquals($this->plugin->getRequirements(), $this->getDummyInfo()->requires);
+        $this->assertEquals($this->plugin->getRequiredCoreVersion(), $this->getDummyInfo()->requires->core);
     }
 
-    public function testMethodsDependingOnRegister(){
+    public function testMethodsDependingOnRegister()
+    {
 
 
-    	$returnRouteOptions = [
-				'middleware' => ['web'],
-				'namespace' => "\Plugin\\".$this->dummyName."\\App\\",
-				'prefix' => $this->plugin->getSlug(),
-		];
+        $returnRouteOptions = [
+            'middleware' => ['web'],
+            'namespace' => "\Plugin\\" . $this->dummyName . "\\App\\",
+            'prefix' => $this->plugin->getSlug(),
+        ];
 
-		$this->assertFalse($this->plugin->hasRegisterClass());
+        $this->assertFalse($this->plugin->hasRegisterClass());
 
-    	$externalMock = \Mockery::mock("overload:\Plugin\\".$this->dummyName."\\Register");
+        $externalMock = \Mockery::mock("overload:\Plugin\\" . $this->dummyName . "\\Register");
         $externalMock->shouldReceive('webRouteOptions')
             ->andReturn($returnRouteOptions);
 
@@ -100,9 +104,9 @@ class PluginModelTest extends TestCase
 
         $default = ['test'];
         $this->assertNull($this->plugin->getRegister("dummy"));
-        $this->assertEquals($this->plugin->getRegister("dummy",$default),$default);
-       // $this->assertInternalType('array',$this->plugin->getRegister('webRouteOptions'));
-       // $this->assertEquals($this->plugin->getRegister('webRouteOptions'),$returnRouteOptions);
+        $this->assertEquals($this->plugin->getRegister("dummy", $default), $default);
+        // $this->assertInternalType('array',$this->plugin->getRegister('webRouteOptions'));
+        // $this->assertEquals($this->plugin->getRegister('webRouteOptions'),$returnRouteOptions);
 
     }
 
@@ -120,5 +124,4 @@ class PluginModelTest extends TestCase
        // $this->assertFalse($this->plugin->isCompatibleWithCore());
 
     }*/
-
 }

--- a/resources/tests/unit/RouteResolverTest.php
+++ b/resources/tests/unit/RouteResolverTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class RouteResolverTest extends TestCase
 {
 
+    private $router;
 
     /** @before */
     public function instantiateRouter(){
@@ -24,8 +25,8 @@ class RouteResolverTest extends TestCase
 
         $this->assertInstanceOf(\App\Http\RouteResolver::class,$this->router);
         
-        $this->assertObjectHasAttribute('defaultNamespace',$this->router);
-        $this->assertObjectHasAttribute('namespace',$this->router);
+        $this->assertObjectHasProperty('defaultNamespace',$this->router);
+        $this->assertObjectHasProperty('namespace',$this->router);
 
 
     }

--- a/resources/tests/unit/RouteResolverTest.php
+++ b/resources/tests/unit/RouteResolverTest.php
@@ -4,6 +4,9 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 class RouteResolverTest extends TestCase
 {
 
@@ -74,8 +77,6 @@ class RouteResolverTest extends TestCase
 
         $controllerString = 'install';
 
-
-        $this->assertInstanceOf(\App\Libs\Controller::class,\App::make($this->router->resolveControllerClass($controllerString)));
         $this->assertInstanceOf(\App\Controllers\InstallController::class,\App::make($this->router->resolveControllerClass($controllerString)));
 
         $this->router->changeNamespace("\App\\Controllers\\Auth\\"); 

--- a/resources/tests/unit/RouteResolverTest.php
+++ b/resources/tests/unit/RouteResolverTest.php
@@ -13,7 +13,8 @@ class RouteResolverTest extends TestCase
     private $router;
 
     /** @before */
-    public function instantiateRouter(){
+    public function instantiateRouter()
+    {
 
         $this->router = new \App\Http\RouteResolver();
     }
@@ -23,73 +24,71 @@ class RouteResolverTest extends TestCase
      *
      * @return void
      */
-    public function testRoutingInitiation(){
+    public function testRoutingInitiation()
+    {
 
 
-        $this->assertInstanceOf(\App\Http\RouteResolver::class,$this->router);
-        
-        $this->assertObjectHasProperty('defaultNamespace',$this->router);
-        $this->assertObjectHasProperty('namespace',$this->router);
+        $this->assertInstanceOf(\App\Http\RouteResolver::class, $this->router);
 
-
+        $this->assertObjectHasProperty('defaultNamespace', $this->router);
+        $this->assertObjectHasProperty('namespace', $this->router);
     }
 
 
-    public function testRoutingMethodExistance(){
+    public function testRoutingMethodExistance()
+    {
 
 
-         $methods = [
-                    'resetNamespace',
-                    'changeNamespace',
-                    'resolveControllerClass',
-                    'resolve'
-                    ];
+        $methods = [
+            'resetNamespace',
+            'changeNamespace',
+            'resolveControllerClass',
+            'resolve'
+        ];
 
-         foreach($methods as $method){
-            $this->assertTrue(method_exists($this->router, $method),'Method ['.$method.'] does not exists in class ['.get_class($this->router).']');
-         }
-
-
+        foreach ($methods as $method) {
+            $this->assertTrue(method_exists($this->router, $method), 'Method [' . $method . '] does not exists in class [' . get_class($this->router) . ']');
+        }
     }
 
 
-    public function testRouteNamespacing(){
+    public function testRouteNamespacing()
+    {
 
         $defaultNamespace = "\App\\Controllers\\";
 
-        $this->assertEquals($this->router->namespace,$defaultNamespace);
+        $this->assertEquals($this->router->namespace, $defaultNamespace);
 
         $changeNamespaceTo = "\App\TestingNamespace";
 
         $this->router->changeNamespace($changeNamespaceTo);
 
-        $this->assertEquals($this->router->namespace,$changeNamespaceTo);
+        $this->assertEquals($this->router->namespace, $changeNamespaceTo);
 
         $this->router->resetNamespace();
 
-        $this->assertEquals($this->router->namespace,$defaultNamespace);
-
+        $this->assertEquals($this->router->namespace, $defaultNamespace);
     }
 
 
 
-    public function testControllerResolving(){
+    public function testControllerResolving()
+    {
 
         $controllerString = 'install';
 
-        $this->assertInstanceOf(\App\Controllers\InstallController::class,\App::make($this->router->resolveControllerClass($controllerString)));
+        $this->assertInstanceOf(\App\Controllers\InstallController::class, \App::make($this->router->resolveControllerClass($controllerString)));
 
-        $this->router->changeNamespace("\App\\Controllers\\Auth\\"); 
+        $this->router->changeNamespace("\App\\Controllers\\Auth\\");
 
         $controllerString = 'login';
 
-        $this->assertInstanceOf(\App\Controllers\Auth\LoginController::class,\App::make($this->router->resolveControllerClass($controllerString)));
-
-
+        $this->assertInstanceOf(\App\Controllers\Auth\LoginController::class, \App::make($this->router->resolveControllerClass($controllerString)));
     }
 
-    public function testControllerNotExsistException(){
-        
+    public function testControllerNotExsistException()
+    {
+
         $controllerString = 'notexistingcontrollername';
 
         $this->expectException(\App\Exceptions\FileNotFoundException::class);
@@ -98,11 +97,11 @@ class RouteResolverTest extends TestCase
     }
 
 
-    public function testRouteNotExsistsExceptionIsThrown(){
+    public function testRouteNotExsistsExceptionIsThrown()
+    {
 
         $this->expectException(\BadMethodCallException::class);
 
-        $this->router->resolve('dashboard','missing-method'); //53
+        $this->router->resolve('dashboard', 'missing-method'); //53
     }
-
 }

--- a/resources/tests/unit/SearchEngineTest.php
+++ b/resources/tests/unit/SearchEngineTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class SearchEngineTest extends TestCase
 {
 
+    protected $engine;
 
     protected function setUp() : void {
         parent::setUp();
@@ -23,8 +24,8 @@ class SearchEngineTest extends TestCase
 
         $this->assertInstanceOf(\App\Libs\SearchEngine::class,$this->engine);
         
-        $this->assertObjectHasAttribute('searchModels',$this->engine);
-        $this->assertObjectHasAttribute('searchKey',$this->engine);
+        $this->assertObjectHasProperty('searchModels',$this->engine);
+        $this->assertObjectHasProperty('searchKey',$this->engine);
     }
 
 

--- a/resources/tests/unit/SearchEngineTest.php
+++ b/resources/tests/unit/SearchEngineTest.php
@@ -9,7 +9,8 @@ class SearchEngineTest extends TestCase
 
     protected $engine;
 
-    protected function setUp() : void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->engine = new \App\Libs\SearchEngine();
     }
@@ -19,66 +20,66 @@ class SearchEngineTest extends TestCase
      *
      * @return void
      */
-    public function testSearchEngineInitiation(){
+    public function testSearchEngineInitiation()
+    {
 
 
-        $this->assertInstanceOf(\App\Libs\SearchEngine::class,$this->engine);
-        
-        $this->assertObjectHasProperty('searchModels',$this->engine);
-        $this->assertObjectHasProperty('searchKey',$this->engine);
+        $this->assertInstanceOf(\App\Libs\SearchEngine::class, $this->engine);
+
+        $this->assertObjectHasProperty('searchModels', $this->engine);
+        $this->assertObjectHasProperty('searchKey', $this->engine);
     }
 
 
-    public function testRoutingMethodExistance(){
+    public function testRoutingMethodExistance()
+    {
 
 
-         $methods = [
-                    'registerModel',
-                    'executeSearch',
-                    'getResultsFor',
-                    ];
+        $methods = [
+            'registerModel',
+            'executeSearch',
+            'getResultsFor',
+        ];
 
-         foreach($methods as $method){
-            $this->assertTrue(method_exists($this->engine, $method),'Method ['.$method.'] does not exists in class ['.get_class($this->engine).']');
-         }
-
-
+        foreach ($methods as $method) {
+            $this->assertTrue(method_exists($this->engine, $method), 'Method [' . $method . '] does not exists in class [' . get_class($this->engine) . ']');
+        }
     }
 
 
-    public function testGetterAndSetterModel(){
+    public function testGetterAndSetterModel()
+    {
 
-       $this->assertIsArray($this->engine->getRegisteredModels());
-       $this->assertEquals(0,count($this->engine->getRegisteredModels()));
-       $this->engine->registerModel(\App\Model\Page::class);
-       $this->assertEquals(1,count($this->engine->getRegisteredModels()));
-
-       $this->assertEquals(0,count($this->engine->getResultsFor(\App\Libs\Page::class)));
-
-    }
-
-    public function testExecuteSearch(){
-    
+        $this->assertIsArray($this->engine->getRegisteredModels());
+        $this->assertEquals(0, count($this->engine->getRegisteredModels()));
         $this->engine->registerModel(\App\Model\Page::class);
-        $this->engine->executeSearch('home'); 
-        $this->assertEquals(1,count($this->engine->getResultsFor(\App\Model\Page::class)));
+        $this->assertEquals(1, count($this->engine->getRegisteredModels()));
 
+        $this->assertEquals(0, count($this->engine->getResultsFor(\App\Libs\Page::class)));
     }
 
-    public function testClearResults(){
+    public function testExecuteSearch()
+    {
+
         $this->engine->registerModel(\App\Model\Page::class);
-        $this->engine->executeSearch('home'); 
-        $this->assertEquals(1,count($this->engine->getResultsFor(\App\Model\Page::class)));
-        $this->engine->clearResults();
-        $this->assertEquals(0,count($this->engine->getResultsFor(\App\Model\Page::class)));
-
+        $this->engine->executeSearch('home');
+        $this->assertEquals(1, count($this->engine->getResultsFor(\App\Model\Page::class)));
     }
 
-    public function testSearchKey(){
-        $this->engine->executeSearch('home'); 
-        $this->assertEquals('home',$this->engine->getSearchKey());
+    public function testClearResults()
+    {
+        $this->engine->registerModel(\App\Model\Page::class);
+        $this->engine->executeSearch('home');
+        $this->assertEquals(1, count($this->engine->getResultsFor(\App\Model\Page::class)));
         $this->engine->clearResults();
-        $this->assertEquals(null,$this->engine->getSearchKey());
+        $this->assertEquals(0, count($this->engine->getResultsFor(\App\Model\Page::class)));
     }
 
+    public function testSearchKey()
+    {
+        $this->engine->executeSearch('home');
+        $this->assertEquals('home', $this->engine->getSearchKey());
+        $this->engine->clearResults();
+        $this->assertEquals(null, $this->engine->getSearchKey());
+    }
 }

--- a/resources/tests/unit/ViewResolverTest.php
+++ b/resources/tests/unit/ViewResolverTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @deprecated deprecated since version 1.0.0
+ */
 class ViewResolverTest extends TestCase
 {
 	private $viewResolver;
@@ -37,8 +40,6 @@ class ViewResolverTest extends TestCase
     	$titleText = "test-title";
     	$addCss = "test.css";
     	$addJs = "test.js";
-    	$addMetaName = "test-meta-name";
-    	$addMetaData = "test-meta-data";
 
 		$this->viewResolver->title($titleText);    	
 
@@ -49,12 +50,6 @@ class ViewResolverTest extends TestCase
 
 		$this->viewResolver->js($addJs);
 		$this->assertTrue(in_array($addJs, $this->viewResolver->data["js"]));
-
-		$this->viewResolver->meta($addMetaName,$addMetaData);
-
-
-		$this->assertTrue($this->inArrayRecurse($addMetaName, $this->viewResolver->data["meta"]));
-		$this->assertTrue($this->inArrayRecurse($addMetaData, $this->viewResolver->data["meta"]));
 
     }
 

--- a/resources/tests/unit/ViewResolverTest.php
+++ b/resources/tests/unit/ViewResolverTest.php
@@ -7,59 +7,58 @@ class ViewResolverTest extends TestCase
 {
 	private $viewResolver;
 
-	public function inArrayRecurse($needle,$haystack){
-		foreach($haystack as $value)
-		{
-		    if(in_array($needle, $value, true))
-		    {
-		        return true;
-		    }
+	public function inArrayRecurse($needle, $haystack)
+	{
+		foreach ($haystack as $value) {
+			if (in_array($needle, $value, true)) {
+				return true;
+			}
 		}
 
 		return false;
 	}
 
 
-    protected function setUp() : void{
+	protected function setUp(): void
+	{
 		parent::setUp();
 		$this->viewResolver = new \App\Libs\ViewResolver();
-    }
+	}
 
 
-    public function testDataArraysSet(){
+	public function testDataArraysSet()
+	{
 
-    	$this->assertEquals(\Config::get('horizontcms.css'), $this->viewResolver->data['css']);
-    	$this->assertEquals(\Config::get('horizontcms.js'), $this->viewResolver->data['js']);
-
-    }
-
-
-    public function testSetters(){
+		$this->assertEquals(\Config::get('horizontcms.css'), $this->viewResolver->data['css']);
+		$this->assertEquals(\Config::get('horizontcms.js'), $this->viewResolver->data['js']);
+	}
 
 
-    	$titleText = "test-title";
-    	$addCss = "test.css";
-    	$addJs = "test.js";
+	public function testSetters()
+	{
 
-		$this->viewResolver->title($titleText);    	
 
-		$this->assertEquals($titleText,$this->viewResolver->data["title"]);
+		$titleText = "test-title";
+		$addCss = "test.css";
+		$addJs = "test.js";
+
+		$this->viewResolver->title($titleText);
+
+		$this->assertEquals($titleText, $this->viewResolver->data["title"]);
 
 		$this->viewResolver->css($addCss);
 		$this->assertTrue(in_array($addCss, $this->viewResolver->data["css"]));
 
 		$this->viewResolver->js($addJs);
 		$this->assertTrue(in_array($addJs, $this->viewResolver->data["js"]));
+	}
 
-    }
 
+	public function testRender()
+	{
 
-    public function testRender(){
+		$this->assertTrue($this->viewResolver->render("dashboard.index", ["testkey1" => "test1", "testkey2" => "test2"])->offsetExists('testkey1'));
 
-		$this->assertTrue($this->viewResolver->render("dashboard.index",["testkey1" => "test1","testkey2" => "test2"])->offsetExists('testkey1'));
-
-		$this->assertEquals('test1',$this->viewResolver->render("dashboard.index",["testkey1" => "test1","testkey2" => "test2"])->offsetGet('testkey1'));
-
-    }
-
+		$this->assertEquals('test1', $this->viewResolver->render("dashboard.index", ["testkey1" => "test1", "testkey2" => "test2"])->offsetGet('testkey1'));
+	}
 }

--- a/resources/tests/unit/WidgetResolverTest.php
+++ b/resources/tests/unit/WidgetResolverTest.php
@@ -4,33 +4,32 @@ class WidgetResolverTest extends TestCase
 {
 
 
-    public function testSetterAndGetter(){
+	public function testSetterAndGetter()
+	{
 
-    	$widgetResolver = new \App\Libs\ShortCode();
+		$widgetResolver = new \App\Libs\ShortCode();
 
-    	$widgetResolver->addWidget('{[TestingWidget]}','WidgetResolved');
+		$widgetResolver->addWidget('{[TestingWidget]}', 'WidgetResolved');
 
-    	$this->assertEquals($widgetResolver->getWidget('{[TestingWidget]}'),'WidgetResolved');
-
-    }
-
-
-    public function testWidgetResolving(){
-
-    	$content = "Some sample text for testing the {[TestingWidget1]} and {[TestingWidget2]} resolving";
-
-    	$widgetResolver = new \App\Libs\ShortCode();
-
-    	$widgetResolver->addWidget('{[TestingWidget1]}','WidgetResolved1');
-
-    	$widgetResolver->addWidget('{[TestingWidget2]}','WidgetResolved2');
-
-    	$resolvedContent = $widgetResolver->compile($content);
-
-    	$this->assertMatchesRegularExpression('/WidgetResolved1/', $resolvedContent);
-
-    	$this->assertMatchesRegularExpression('/WidgetResolved2/', $resolvedContent);
-    }
+		$this->assertEquals($widgetResolver->getWidget('{[TestingWidget]}'), 'WidgetResolved');
+	}
 
 
+	public function testWidgetResolving()
+	{
+
+		$content = "Some sample text for testing the {[TestingWidget1]} and {[TestingWidget2]} resolving";
+
+		$widgetResolver = new \App\Libs\ShortCode();
+
+		$widgetResolver->addWidget('{[TestingWidget1]}', 'WidgetResolved1');
+
+		$widgetResolver->addWidget('{[TestingWidget2]}', 'WidgetResolved2');
+
+		$resolvedContent = $widgetResolver->compile($content);
+
+		$this->assertMatchesRegularExpression('/WidgetResolved1/', $resolvedContent);
+
+		$this->assertMatchesRegularExpression('/WidgetResolved2/', $resolvedContent);
+	}
 }


### PR DESCRIPTION
One of the oldest class in the CMS is the `\App\Libs\Controller` class. It's time to say goodbye to it and remove all of the references to this class. It makes the whole unit testing painfull.

Currently it's going to be marked as depreceted and slowly all of the controller classes will be reassigned to Laravel's BaseController. 

Later the plugins will follow and all of them will be upgraded to the new behaviour.